### PR TITLE
fix for config tab missing permission required attribute

### DIFF
--- a/peering/views.py
+++ b/peering/views.py
@@ -530,6 +530,8 @@ class IXPeers(ModelListView):
 
 
 class IXConfig(PermissionRequiredMixin, View):
+    permission_required = 'peering.change_internetexchange'
+    
     def get(self, request, slug):
         internet_exchange = get_object_or_404(InternetExchange, slug=slug)
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Peering Manager! Please
    indicate if your changes fix bugs or feature requests created in the issue
    tracker. This helps to avoid wasting time and effort to check for this
    before merging the code.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes:
Error:
When going to the config tab we get the following error, fix is to eliminate that, seems like permission_required was missing from the IXConfig class.

 IXConfig is missing the permission_required attribute. Define IXConfig.permission_required, or override IXConfig.get_permission_required().

<!--
    Please include a summary of the proposed changes below.
-->


Please let me know if that is the proper config for permissions, I could not find the list of all the permissions.