### PR TITLE
Display comments when appropriate

### DIFF
--- a/peering/tables.py
+++ b/peering/tables.py
@@ -43,6 +43,9 @@ INTERNET_EXCHANGE_PEERING_SESSION_ACTIONS = """
 {% if record.autonomous_system.comment %}
 <button type="button" class="btn btn-sm btn-info popover-hover" data-toggle="popover" data-html="true" title="Autonomous System Comments" data-content="{{ record.autonomous_system.comment | markdown }}"><i class="fas fa-comments"></i></button>
 {% endif %}
+{% if record.internet_exchange.comment %}
+<button type="button" class="btn btn-sm btn-info popover-hover" data-toggle="popover" data-html="true" title="Internet Exchange Comments" data-content="{{ record.internet_exchange.comment | markdown }}"><i class="fas fa-comment-dots"></i></button>
+{% endif %}
 <a href="{% url 'peering:internet_exchange_peering_session_edit' pk=record.pk %}" class="btn btn-sm btn-warning"><i class="fas fa-edit"></i></a>
 """
 INTERNET_EXCHANGE_PEERING_SESSION_IS_ROUTE_SERVER = """

--- a/peering/tables.py
+++ b/peering/tables.py
@@ -70,7 +70,7 @@ class AutonomousSystemTable(BaseTable):
         template_code=AUTONOMOUS_SYSTEM_HAS_POTENTIAL_IX_PEERING_SESSIONS,
     )
     actions = ActionsColumn(
-        template_code='<a href="{% url \'peering:autonomous_system_edit\' asn=record.asn %}" class="btn btn-sm btn-warning"><i class="fas fa-edit"></i> Edit</a>'
+        template_code='<a href="{% url \'peering:autonomous_system_edit\' asn=record.asn %}" class="btn btn-sm btn-warning"><i class="fas fa-edit"></i></a>'
     )
 
     class Meta(BaseTable.Meta):
@@ -95,7 +95,7 @@ class CommunityTable(BaseTable):
     name = tables.LinkColumn()
     type = tables.TemplateColumn(template_code=COMMUNITY_TYPE)
     actions = ActionsColumn(
-        template_code='<a href="{% url \'peering:community_edit\' pk=record.pk %}" class="btn btn-sm btn-warning"><i class="fas fa-edit"></i> Edit</a>'
+        template_code='<a href="{% url \'peering:community_edit\' pk=record.pk %}" class="btn btn-sm btn-warning"><i class="fas fa-edit"></i></a>'
     )
 
     class Meta(BaseTable.Meta):
@@ -111,7 +111,7 @@ class ConfigurationTemplateTable(BaseTable):
     pk = SelectColumn()
     name = tables.LinkColumn()
     actions = ActionsColumn(
-        template_code='<a href="{% url \'peering:configuration_template_edit\' pk=record.pk %}" class="btn btn-sm btn-warning"><i class="fas fa-edit"></i> Edit</a>'
+        template_code='<a href="{% url \'peering:configuration_template_edit\' pk=record.pk %}" class="btn btn-sm btn-warning"><i class="fas fa-edit"></i></a>'
     )
 
     class Meta(BaseTable.Meta):
@@ -161,7 +161,7 @@ class InternetExchangeTable(BaseTable):
     )
     router = tables.RelatedLinkColumn(verbose_name="Router", accessor="router")
     actions = ActionsColumn(
-        template_code='<a href="{% url \'peering:internet_exchange_edit\' slug=record.slug %}" class="btn btn-sm btn-warning"><i class="fas fa-edit"></i> Edit</a>'
+        template_code='<a href="{% url \'peering:internet_exchange_edit\' slug=record.slug %}" class="btn btn-sm btn-warning"><i class="fas fa-edit"></i></a>'
     )
 
     class Meta(BaseTable.Meta):
@@ -202,7 +202,7 @@ class InternetExchangePeeringSessionTable(BaseTable):
         verbose_name="Status", template_code=BGPSESSION_STATUS
     )
     actions = ActionsColumn(
-        template_code='{% load helpers %}<div class="float-right">{% if record.comment %}<button type="button" class="btn btn-sm btn-info popover-hover" data-toggle="popover" data-html="true" title="Comments" data-content="{{ record.comment | markdown }}"><i class="fas fa-comment"></i></button> {% endif %}<a href="{% url \'peering:internet_exchange_peering_session_edit\' pk=record.pk %}" class="btn btn-sm btn-warning"><i class="fas fa-edit"></i> Edit</a></div>'
+        template_code='{% load helpers %}{% if record.comment %}<button type="button" class="btn btn-sm btn-info popover-hover" data-toggle="popover" data-html="true" title="Comments" data-content="{{ record.comment | markdown }}"><i class="fas fa-comment"></i></button> {% endif %}<a href="{% url \'peering:internet_exchange_peering_session_edit\' pk=record.pk %}" class="btn btn-sm btn-warning"><i class="fas fa-edit"></i></a>'
     )
 
     class Meta(BaseTable.Meta):
@@ -242,7 +242,7 @@ class InternetExchangePeeringSessionTableForIX(BaseTable):
     )
     session_state = BGPSessionStateColumn(accessor="bgp_state")
     actions = ActionsColumn(
-        template_code='{% load helpers %}<div class="float-right">{% if record.comment %}<button type="button" class="btn btn-sm btn-info popover-hover" data-toggle="popover" data-html="true" title="Comments" data-content="{{ record.comment | markdown }}"><i class="fas fa-comment"></i></button> {% endif %}<a href="{% url \'peering:internet_exchange_peering_session_edit\' pk=record.pk %}" class="btn btn-sm btn-warning"><i class="fas fa-edit"></i> Edit</a></div>'
+        template_code='{% load helpers %}{% if record.comment %}<button type="button" class="btn btn-sm btn-info popover-hover" data-toggle="popover" data-html="true" title="Comments" data-content="{{ record.comment | markdown }}"><i class="fas fa-comment"></i></button> {% endif %}<a href="{% url \'peering:internet_exchange_peering_session_edit\' pk=record.pk %}" class="btn btn-sm btn-warning"><i class="fas fa-edit"></i></a>'
     )
 
     class Meta(BaseTable.Meta):
@@ -279,7 +279,7 @@ class InternetExchangePeeringSessionTableForAS(BaseTable):
     )
     session_state = BGPSessionStateColumn(accessor="bgp_state")
     actions = ActionsColumn(
-        template_code='{% load helpers %}<div class="float-right">{% if record.comment %}<button type="button" class="btn btn-sm btn-info popover-hover" data-toggle="popover" data-html="true" title="Comments" data-content="{{ record.comment | markdown }}"><i class="fas fa-comment"></i></button> {% endif %}<a href="{% url \'peering:internet_exchange_peering_session_edit\' pk=record.pk %}" class="btn btn-sm btn-warning"><i class="fas fa-edit"></i> Edit</a></div>'
+        template_code='{% load helpers %}{% if record.comment %}<button type="button" class="btn btn-sm btn-info popover-hover" data-toggle="popover" data-html="true" title="Comments" data-content="{{ record.comment | markdown }}"><i class="fas fa-comment"></i></button> {% endif %}<a href="{% url \'peering:internet_exchange_peering_session_edit\' pk=record.pk %}" class="btn btn-sm btn-warning"><i class="fas fa-edit"></i></a>'
     )
 
     class Meta(BaseTable.Meta):
@@ -342,7 +342,7 @@ class RouterTable(BaseTable):
     pk = SelectColumn()
     name = tables.LinkColumn()
     actions = ActionsColumn(
-        template_code='<a href="{% url \'peering:router_edit\' pk=record.pk %}" class="btn btn-sm btn-warning"><i class="fas fa-edit"></i> Edit</a>'
+        template_code='<a href="{% url \'peering:router_edit\' pk=record.pk %}" class="btn btn-sm btn-warning"><i class="fas fa-edit"></i></a>'
     )
 
     class Meta(BaseTable.Meta):
@@ -359,7 +359,7 @@ class RoutingPolicyTable(BaseTable):
     name = tables.LinkColumn()
     type = tables.TemplateColumn(template_code=ROUTING_POLICY_TYPE)
     actions = ActionsColumn(
-        template_code='<a href="{% url \'peering:routing_policy_edit\' pk=record.pk %}" class="btn btn-sm btn-warning"><i class="fas fa-edit"></i> Edit</a>'
+        template_code='<a href="{% url \'peering:routing_policy_edit\' pk=record.pk %}" class="btn btn-sm btn-warning"><i class="fas fa-edit"></i></a>'
     )
 
     class Meta(BaseTable.Meta):

--- a/peering/tables.py
+++ b/peering/tables.py
@@ -12,6 +12,7 @@ from .models import (
 )
 from peeringdb.models import PeerRecord
 from utils.tables import ActionsColumn, BaseTable, SelectColumn
+from utils.templatetags.helpers import markdown
 
 
 AUTONOMOUS_SYSTEM_HAS_POTENTIAL_IX_PEERING_SESSIONS = """
@@ -201,7 +202,7 @@ class InternetExchangePeeringSessionTable(BaseTable):
         verbose_name="Status", template_code=BGPSESSION_STATUS
     )
     actions = ActionsColumn(
-        template_code='<div class="float-right"><a href="{% url \'peering:internet_exchange_peering_session_edit\' pk=record.pk %}" class="btn btn-sm btn-warning"><i class="fas fa-edit"></i> Edit</a></div>'
+        template_code='{% load helpers %}<div class="float-right">{% if record.comment %}<button type="button" class="btn btn-sm btn-info popover-hover" data-toggle="popover" data-html="true" title="Comments" data-content="{{ record.comment | markdown }}"><i class="fas fa-comment"></i></button> {% endif %}<a href="{% url \'peering:internet_exchange_peering_session_edit\' pk=record.pk %}" class="btn btn-sm btn-warning"><i class="fas fa-edit"></i> Edit</a></div>'
     )
 
     class Meta(BaseTable.Meta):
@@ -241,7 +242,7 @@ class InternetExchangePeeringSessionTableForIX(BaseTable):
     )
     session_state = BGPSessionStateColumn(accessor="bgp_state")
     actions = ActionsColumn(
-        template_code='<div class="float-right"><a href="{% url \'peering:internet_exchange_peering_session_edit\' pk=record.pk %}" class="btn btn-sm btn-warning"><i class="fas fa-edit"></i> Edit</a></div>'
+        template_code='{% load helpers %}<div class="float-right">{% if record.comment %}<button type="button" class="btn btn-sm btn-info popover-hover" data-toggle="popover" data-html="true" title="Comments" data-content="{{ record.comment | markdown }}"><i class="fas fa-comment"></i></button> {% endif %}<a href="{% url \'peering:internet_exchange_peering_session_edit\' pk=record.pk %}" class="btn btn-sm btn-warning"><i class="fas fa-edit"></i> Edit</a></div>'
     )
 
     class Meta(BaseTable.Meta):
@@ -278,7 +279,7 @@ class InternetExchangePeeringSessionTableForAS(BaseTable):
     )
     session_state = BGPSessionStateColumn(accessor="bgp_state")
     actions = ActionsColumn(
-        template_code='<div class="float-right"><a href="{% url \'peering:internet_exchange_peering_session_edit\' pk=record.pk %}" class="btn btn-sm btn-warning"><i class="fas fa-edit"></i> Edit</a></div>'
+        template_code='{% load helpers %}<div class="float-right">{% if record.comment %}<button type="button" class="btn btn-sm btn-info popover-hover" data-toggle="popover" data-html="true" title="Comments" data-content="{{ record.comment | markdown }}"><i class="fas fa-comment"></i></button> {% endif %}<a href="{% url \'peering:internet_exchange_peering_session_edit\' pk=record.pk %}" class="btn btn-sm btn-warning"><i class="fas fa-edit"></i> Edit</a></div>'
     )
 
     class Meta(BaseTable.Meta):

--- a/peering/tables.py
+++ b/peering/tables.py
@@ -25,6 +25,26 @@ AUTONOMOUS_SYSTEM_HAS_POTENTIAL_IX_PEERING_SESSIONS = """
 BGPSESSION_STATUS = "{{ record.get_enabled_html }}"
 BGP_RELATIONSHIP = "{{ record.get_relationship_html }}"
 COMMUNITY_TYPE = "{{ record.get_type_html }}"
+DIRECT_PEERING_SESSION_ACTIONS = """
+{% load helpers %}
+{% if record.comment %}
+<button type="button" class="btn btn-sm btn-info popover-hover" data-toggle="popover" data-html="true" title="Peering Session Comments" data-content="{{ record.comment | markdown }}"><i class="fas fa-comment"></i></button>
+{% endif %}
+{% if record.autonomous_system.comment %}
+<button type="button" class="btn btn-sm btn-info popover-hover" data-toggle="popover" data-html="true" title="Autonomous System Comments" data-content="{{ record.autonomous_system.comment | markdown }}"><i class="fas fa-comments"></i></button>
+{% endif %}
+<a href="{% url 'peering:direct_peering_session_edit' pk=record.pk %}" class="btn btn-sm btn-warning"><i class="fas fa-edit"></i></a>
+"""
+INTERNET_EXCHANGE_PEERING_SESSION_ACTIONS = """
+{% load helpers %}
+{% if record.comment %}
+<button type="button" class="btn btn-sm btn-info popover-hover" data-toggle="popover" data-html="true" title="Peering Session Comments" data-content="{{ record.comment | markdown }}"><i class="fas fa-comment"></i></button>
+{% endif %}
+{% if record.autonomous_system.comment %}
+<button type="button" class="btn btn-sm btn-info popover-hover" data-toggle="popover" data-html="true" title="Autonomous System Comments" data-content="{{ record.autonomous_system.comment | markdown }}"><i class="fas fa-comments"></i></button>
+{% endif %}
+<a href="{% url 'peering:internet_exchange_peering_session_edit' pk=record.pk %}" class="btn btn-sm btn-warning"><i class="fas fa-edit"></i></a>
+"""
 INTERNET_EXCHANGE_PEERING_SESSION_IS_ROUTE_SERVER = """
 {% if record.is_route_server %}
 <i class="fas fa-check-square text-success"></i>
@@ -134,6 +154,7 @@ class DirectPeeringSessionTable(BaseTable):
         verbose_name="Status", template_code=BGPSESSION_STATUS
     )
     session_state = BGPSessionStateColumn(accessor="bgp_state")
+    actions = ActionsColumn(template_code=DIRECT_PEERING_SESSION_ACTIONS)
 
     class Meta(BaseTable.Meta):
         model = DirectPeeringSession
@@ -144,6 +165,7 @@ class DirectPeeringSessionTable(BaseTable):
             "relationship",
             "enabled",
             "session_state",
+            "actions",
         )
 
 
@@ -201,9 +223,7 @@ class InternetExchangePeeringSessionTable(BaseTable):
     enabled = tables.TemplateColumn(
         verbose_name="Status", template_code=BGPSESSION_STATUS
     )
-    actions = ActionsColumn(
-        template_code='{% load helpers %}{% if record.comment %}<button type="button" class="btn btn-sm btn-info popover-hover" data-toggle="popover" data-html="true" title="Comments" data-content="{{ record.comment | markdown }}"><i class="fas fa-comment"></i></button> {% endif %}<a href="{% url \'peering:internet_exchange_peering_session_edit\' pk=record.pk %}" class="btn btn-sm btn-warning"><i class="fas fa-edit"></i></a>'
-    )
+    actions = ActionsColumn(template_code=INTERNET_EXCHANGE_PEERING_SESSION_ACTIONS)
 
     class Meta(BaseTable.Meta):
         model = InternetExchangePeeringSession
@@ -241,9 +261,7 @@ class InternetExchangePeeringSessionTableForIX(BaseTable):
         verbose_name="Status", template_code=BGPSESSION_STATUS
     )
     session_state = BGPSessionStateColumn(accessor="bgp_state")
-    actions = ActionsColumn(
-        template_code='{% load helpers %}{% if record.comment %}<button type="button" class="btn btn-sm btn-info popover-hover" data-toggle="popover" data-html="true" title="Comments" data-content="{{ record.comment | markdown }}"><i class="fas fa-comment"></i></button> {% endif %}<a href="{% url \'peering:internet_exchange_peering_session_edit\' pk=record.pk %}" class="btn btn-sm btn-warning"><i class="fas fa-edit"></i></a>'
-    )
+    actions = ActionsColumn(template_code=INTERNET_EXCHANGE_PEERING_SESSION_ACTIONS)
 
     class Meta(BaseTable.Meta):
         model = InternetExchangePeeringSession
@@ -278,9 +296,7 @@ class InternetExchangePeeringSessionTableForAS(BaseTable):
         verbose_name="Status", template_code=BGPSESSION_STATUS
     )
     session_state = BGPSessionStateColumn(accessor="bgp_state")
-    actions = ActionsColumn(
-        template_code='{% load helpers %}{% if record.comment %}<button type="button" class="btn btn-sm btn-info popover-hover" data-toggle="popover" data-html="true" title="Comments" data-content="{{ record.comment | markdown }}"><i class="fas fa-comment"></i></button> {% endif %}<a href="{% url \'peering:internet_exchange_peering_session_edit\' pk=record.pk %}" class="btn btn-sm btn-warning"><i class="fas fa-edit"></i></a>'
-    )
+    actions = ActionsColumn(template_code=INTERNET_EXCHANGE_PEERING_SESSION_ACTIONS)
 
     class Meta(BaseTable.Meta):
         model = InternetExchangePeeringSession

--- a/project-static/js/base.js
+++ b/project-static/js/base.js
@@ -1,0 +1,4 @@
+$(document).ready(function() {
+  // Trigger popover on hover
+  $('.popover-hover').popover({trigger: 'hover'});
+});

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -93,6 +93,7 @@
     <script src="{% static 'js/jquery-3.3.1.min.js' %}"></script>
     <script src="{% static 'bootstrap-4.1.3-dist/js/bootstrap.bundle.min.js' %}"></script>
     <script src="{% static 'bootstrap-select-1.13.2/js/bootstrap-select.min.js' %}"></script>
+    <script src="{% static 'js/base.js' %}?v{{ settings.VERSION }}"></script>
     <script src="{% static 'js/forms.js' %}?v{{ settings.VERSION }}"></script>
     {% block javascript %}{% endblock %}
   </body>

--- a/templates/peering/session/direct/details.html
+++ b/templates/peering/session/direct/details.html
@@ -1,9 +1,13 @@
 {% extends '_base.html' %}
 {% load helpers %}
 {% block content %}
-      <a href="{% url 'peering:autonomous_system_direct_peering_sessions' asn=peering_session.autonomous_system.asn %}" class="btn btn-secondary">
-        <i class="fas fa-arrow-left"></i> Back to AS
-      </a>
+      <nav aria-label="breadcrumb">
+        <ol class="breadcrumb">
+          <li class="breadcrumb-item"><a href="{% url 'peering:autonomous_system_details' asn=peering_session.autonomous_system.asn %}">{{ peering_session.autonomous_system }}</a></li>
+          <li class="breadcrumb-item"><a href="{% url 'peering:autonomous_system_direct_peering_sessions' asn=peering_session.autonomous_system.asn %}">Direct Peering Sessions</a></li>
+          <li class="breadcrumb-item active" aria-current="page">{{ peering_session }}</li>
+        </ol>
+      </nav>
       <div class="float-right">
         {% if perms.peering.change_directpeeringsession %}
         {% if peering_session.enabled %}
@@ -47,7 +51,12 @@
               </tr>
               <tr>
                 <td>AS Name</td>
-                <td>{{ peering_session.autonomous_system.name }}</td>
+                <td>
+                  {{ peering_session.autonomous_system.name }}
+                  {% if peering_session.autonomous_system.comment %}
+                  <span class="float-right badge badge-info popover-hover" data-toggle="popover" data-html="true" title="Autonomous System Comments" data-content="{{ peering_session.autonomous_system.comment | markdown }}"><i class="fas fa-comment"></i></span>
+                  {% endif %}
+                </td>
               </tr>
               <tr>
                 <td>ASN</td>

--- a/templates/peering/session/internet_exchange/details.html
+++ b/templates/peering/session/internet_exchange/details.html
@@ -47,7 +47,12 @@
               </tr>
               <tr>
                 <td>AS Name</td>
-                <td>{{ peering_session.autonomous_system.name }}</td>
+                <td>
+                  {{ peering_session.autonomous_system.name }}
+                  {% if peering_session.autonomous_system.comment %}
+                  <span class="float-right badge badge-info popover-hover" data-toggle="popover" data-html="true" title="Autonomous System Comments" data-content="{{ peering_session.autonomous_system.comment | markdown }}"><i class="fas fa-comment"></i></span>
+                  {% endif %}
+                </td>
               </tr>
               <tr>
                 <td>ASN</td>

--- a/templates/peering/session/internet_exchange/details.html
+++ b/templates/peering/session/internet_exchange/details.html
@@ -43,7 +43,12 @@
             <table class="table table-hover card-body attr-table">
               <tr>
                 <td>Internet Exchange</td>
-                <td>{{ peering_session.internet_exchange }}</td>
+                <td>
+                  {{ peering_session.internet_exchange }}
+                  {% if peering_session.internet_exchange.comment %}
+                  <span class="float-right badge badge-info popover-hover" data-toggle="popover" data-html="true" title="Internet Exchange Comments" data-content="{{ peering_session.internet_exchange.comment | markdown }}"><i class="fas fa-comment"></i></span>
+                  {% endif %}
+                </td>
               </tr>
               <tr>
                 <td>AS Name</td>


### PR DESCRIPTION
### Fixes:

<!--
    Please include a summary of the proposed changes below.
-->

This PR aims to close #69 by displaying comments (being peering session's or other's) when appropriate. This means that comments should be displayed to user to avoid them taking unnecessary actions. There is a pretty good summary of this in the previously mentioned issue.