### PR TITLE
Fix JunOS template in the documentation

### DIFF
--- a/docs/config-template.md
+++ b/docs/config-template.md
@@ -55,6 +55,7 @@ protocols {
                             maximum {{ details.ipv6_max_prefixes }};
                         }
                     }
+                }
                 {%- endif %}
                 {%- if group.ip_version == 4 and details.ipv4_max_prefixes > 0 %}
                 family inet {


### PR DESCRIPTION
### Fixes:

Add missing closing } for IPv6 sessions to generate valid configuration.
