### PR TITLE
Put directory variable above command variable in docs

### DIFF
--- a/docs/setup/3-web-server.md
+++ b/docs/setup/3-web-server.md
@@ -99,8 +99,8 @@ Create a configuration file `/etc/supervisor/conf.d/peering-manager.conf` and
 set its content.
 ```no-highlight
 [program:peering-manager]
-command = gunicorn -c /opt/peering-manager/gunicorn_config.py peering_manager.wsgi
 directory = /opt/peering-manager/
+command = gunicorn -c /opt/peering-manager/gunicorn_config.py peering_manager.wsgi
 user = www-data
 ```
 


### PR DESCRIPTION
When the command variable is listed before the directory variable, supervisor runs the command before it has changed to the specified directory.

Not sure if this is a known bug, but I've seen other people with the same issue [https://serverfault.com/a/834182](https://serverfault.com/a/834182).

### Fixes:

* Moves the directory variable so that it comes before the command variable.
