### PR TITLE
updated cisco iosxr router deploy template

### DIFF
--- a/docs/templates/cisco-iosxr.md
+++ b/docs/templates/cisco-iosxr.md
@@ -1,50 +1,45 @@
-!!! warning
-    This template example needs an update.
-
-```no-highlight
-!
-router bgp 12345
- vrf internet
-  {%- for group in peering_groups %}
-  {%- for asn, details in group.peers.items() %}
-  {%- for session in details.sessions %}
-  neighbor {{ session.ip_address }}
-   {%- if not session.enabled %}
-   shutdown
-   {%- elif session.enabled %}
-   no shutdown
-   {%- endif %}
-   remote-as {{ asn }}
-{#- Seattle #}
-   {%- if 'ixp-six' == internet_exchange.slug %}
-   use neighbor-group IXP-SIX-V{{ group.ip_version }}
-   {%- elif 'ixp-equinix-sea' == internet_exchange.slug %}
-   use neighbor-group IXP-EQUINIX-SEA-V{{ group.ip_version }}
-{#- New York #}
-   {%- elif 'ixp-nyiix' == internet_exchange.slug %}
-   use neighbor-group IXP-NYIIX-V{{ group.ip_version }}
-   {%- elif 'ixp-decix-ny' == internet_exchange.slug %}
-   use neighbor-group IXP-DECIX-NY-V{{ group.ip_version }}
-   {%- elif 'ixp-drix-ny' == internet_exchange.slug %}
-   use neighbor-group IXP-DRIX-NY-V{{ group.ip_version }}
-{#- Montreal -#}
-   {%- elif 'ixp-qix' == internet_exchange.slug %}
-   use neighbor-group IXP-QIX-V{{ group.ip_version }}
-{#- Toronto -#}
-   {%- elif 'ixp-torix' == internet_exchange.slug %}
-   use neighbor-group IXP-TORIX-V{{ group.ip_version }}
-   {%- endif %}
-   {%- if session.password %}
-   password {{ session.password }}
-   {%- endif %}
-   description "AS{{ asn }} - {{ details.as_name }}"
-   address-family {% if group.ip_version == 4 %}ipv4{% else %}ipv6{% endif %} unicast
-    maximum-prefix {% if group.ip_version == 4 %}{{ details.ipv4_max_prefixes }}{% else %}{{ details.ipv6_max_prefixes }}{% endif %} 100 restart 60
-   !
-  !
- {%- endfor %}
- {%- endfor %}
- {%- endfor %}
- !
-!
-```
+router bgp 123456
+{%- for internet_exchange in internet_exchanges %}
+{%- for address_familiy, sessions in internet_exchange.sessions.items() %}
+{%- if sessions|length > 0 %}
+{%- for session in sessions %}
+{% if session.enabled %}
+    neighbor {{ session.ip_address }}
+      remote-as {{ session.autonomous_system.asn }}
+      {%- if session.autonomous_system.irr_as_set %}
+      description {{ session.autonomous_system.name }} ({{ session.autonomous_system.irr_as_set }})
+      {%- else %}
+      description {{ session.autonomous_system.name }}
+      {%- endif %}
+      {%- if session.password %}
+      {%- if '7 ' in session.password %}
+      password encrypted {{ session.password|replace("7 ","") }}
+      {%- else %}
+      password clear {{ session.password }}
+      {%- endif %}
+      {%- endif %}
+      {%- if session.is_route_server %}
+      use neighbor-group ng{{ address_familiy }}-ROUTESRV
+      {%- else %}
+      use neighbor-group ng{{ address_familiy }}-PEERING
+      {%- endif %}
+      address-family ipv{{ address_familiy }} unicast
+      {%- if session.import_routing_policies %}
+        route-policy {{ session.import_routing_policies | map(attribute='name') | join(' ') }} in
+      {%- endif %}
+      {%- if session.export_routing_policies %}
+        route-policy {{ session.import_routing_policies | map(attribute='name') | join(' ') }} out
+      {%- endif %}
+      {%- if address_familiy == 4 and session.autonomous_system.ipv4_max_prefixes > 0 %}
+        maximum-prefix {{ session.autonomous_system.ipv4_max_prefixes }} 95 restart 15
+      {%- endif %}
+      {%- if address_familiy == 6 and session.autonomous_system.ipv6_max_prefixes > 0 %}
+        maximum-prefix {{ session.autonomous_system.ipv6_max_prefixes }} 95 restart 15
+      {%- endif %}
+{%- else %}
+    no neighbor {{ session.ip_address }}
+{%- endif %}
+{%- endfor %}
+{%- endif %}
+{%- endfor %}
+{%- endfor %}


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Peering Manager! Please
    indicate if your changes fix bugs or feature requests created in the issue
    tracker. This helps to avoid wasting time and effort to check for this
    before merging the code.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes:

Updated to match the latest router deployment configuration

Preview of generated config
```
router bgp 123456
  neighbor 2001:7f8::2a:0:1
    remote-as 42
    description Packet Clearing House AS42 (AS-PCH)
    use neighbor-group ng6-PEERING
    address-family ipv6 unicast
      maximum-prefix 600 95 restart 15
```
