### PR TITLE
Fix for issue #158 where changelog shows funny on windows pcs

### DIFF
--- a/project-static/css/base.css
+++ b/project-static/css/base.css
@@ -113,3 +113,6 @@ select#id_per_page {
 div#action_buttons {
   margin-left: 5px;
 }
+.list-group-item {
+  position: inherit !important;
+}


### PR DESCRIPTION

### Fixes:
Issue #158 

In the base.css added the class for the list-group-item to fix the position on the screen where the changelog seems to go over the end line 

