### PR TITLE
docs: fix missing codeblock

### DIFF
--- a/docs/templates/cisco-iosxr.md
+++ b/docs/templates/cisco-iosxr.md
@@ -1,3 +1,4 @@
+```no-highlight
 router bgp 123456
 {%- for internet_exchange in internet_exchanges %}
 {%- for address_familiy, sessions in internet_exchange.sessions.items() %}
@@ -43,3 +44,4 @@ router bgp 123456
 {%- endif %}
 {%- endfor %}
 {%- endfor %}
+```


### PR DESCRIPTION
Cisco IOS XR template example was not wrapped in
a code block.