### PR TITLE
Update documentation and tests to use rfc5737 addresses

### DIFF
--- a/docs/configuration/required-settings.md
+++ b/docs/configuration/required-settings.md
@@ -19,7 +19,7 @@ Peering Manager server).
 Example:
 
 ```no-highlight
-ALLOWED_HOSTS = ['peering.example.com', '192.168.42.42']
+ALLOWED_HOSTS = ['peering.example.com', '192.0.2.42']
 ```
 
 ---

--- a/docs/templates/cisco-iosxr.md
+++ b/docs/templates/cisco-iosxr.md
@@ -1,7 +1,7 @@
 ```no-highlight
-router bgp 123456
+router bgp {{ my_asn }}
 {%- for internet_exchange in internet_exchanges %}
-{%- for address_familiy, sessions in internet_exchange.sessions.items() %}
+{%- for address_family, sessions in internet_exchange.sessions.items() %}
 {%- if sessions|length > 0 %}
 {%- for session in sessions %}
 {% if session.enabled %}
@@ -20,21 +20,21 @@ router bgp 123456
       {%- endif %}
       {%- endif %}
       {%- if session.is_route_server %}
-      use neighbor-group ng{{ address_familiy }}-ROUTESRV
+      use neighbor-group ng{{ address_family }}-ROUTESRV
       {%- else %}
-      use neighbor-group ng{{ address_familiy }}-PEERING
+      use neighbor-group ng{{ address_family }}-PEERING
       {%- endif %}
-      address-family ipv{{ address_familiy }} unicast
+      address-family ipv{{ address_family }} unicast
       {%- if session.import_routing_policies %}
         route-policy {{ session.import_routing_policies | map(attribute='name') | join(' ') }} in
       {%- endif %}
       {%- if session.export_routing_policies %}
         route-policy {{ session.import_routing_policies | map(attribute='name') | join(' ') }} out
       {%- endif %}
-      {%- if address_familiy == 4 and session.autonomous_system.ipv4_max_prefixes > 0 %}
+      {%- if address_family == 4 and session.autonomous_system.ipv4_max_prefixes > 0 %}
         maximum-prefix {{ session.autonomous_system.ipv4_max_prefixes }} 95 restart 15
       {%- endif %}
-      {%- if address_familiy == 6 and session.autonomous_system.ipv6_max_prefixes > 0 %}
+      {%- if address_family == 6 and session.autonomous_system.ipv6_max_prefixes > 0 %}
         maximum-prefix {{ session.autonomous_system.ipv6_max_prefixes }} 95 restart 15
       {%- endif %}
 {%- else %}

--- a/peering/tests/test_api.py
+++ b/peering/tests/test_api.py
@@ -381,7 +381,7 @@ class DirectPeeringSessionTest(APITestCase):
         data = {
             "autonomous_system": self.autonomous_system.pk,
             "relationship": BGP_RELATIONSHIP_PRIVATE_PEERING,
-            "ip_address": "192.168.0.1",
+            "ip_address": "192.0.2.1",
         }
 
         url = reverse("peering-api:directpeeringsession-list")
@@ -399,12 +399,12 @@ class DirectPeeringSessionTest(APITestCase):
             {
                 "autonomous_system": self.autonomous_system.pk,
                 "relationship": BGP_RELATIONSHIP_PRIVATE_PEERING,
-                "ip_address": "10.0.0.1",
+                "ip_address": "198.51.100.1",
             },
             {
                 "autonomous_system": self.autonomous_system.pk,
                 "relationship": BGP_RELATIONSHIP_PRIVATE_PEERING,
-                "ip_address": "10.0.0.2",
+                "ip_address": "198.51.100.2",
             },
         ]
 
@@ -653,7 +653,7 @@ class InternetExchangePeeringSessionTest(APITestCase):
         data = {
             "autonomous_system": self.autonomous_system.pk,
             "internet_exchange": self.internet_exchange.pk,
-            "ip_address": "192.168.0.1",
+            "ip_address": "192.0.2.1",
         }
 
         url = reverse("peering-api:internetexchangepeeringsession-list")
@@ -673,12 +673,12 @@ class InternetExchangePeeringSessionTest(APITestCase):
             {
                 "autonomous_system": self.autonomous_system.pk,
                 "internet_exchange": self.internet_exchange.pk,
-                "ip_address": "10.0.0.1",
+                "ip_address": "198.51.100.1",
             },
             {
                 "autonomous_system": self.autonomous_system.pk,
                 "internet_exchange": self.internet_exchange.pk,
-                "ip_address": "10.0.0.2",
+                "ip_address": "198.51.100.2",
             },
         ]
 

--- a/peering/tests/test_models.py
+++ b/peering/tests/test_models.py
@@ -167,8 +167,8 @@ class InternetExchangeTest(TestCase):
                 # No IP addresses
             },
             {"ipv6_address": "2001:db8::1"},
-            {"ipv4_address": "192.168.168.1"},
-            {"ipv6_address": "2001:db8::1", "ipv4_address": "192.168.168.1"},
+            {"ipv4_address": "198.51.100.1"},
+            {"ipv6_address": "2001:db8::1", "ipv4_address": "198.51.100.1"},
             {"ipv6_address": "2001:7f8:1::a502:9467:1"},
             {"ipv4_address": "80.249.210.208"},
             {
@@ -201,21 +201,21 @@ class InternetExchangeTest(TestCase):
             # First case, one new session with one new AS
             [{"ip_address": ipaddress.ip_address("2001:db8::1"), "remote_asn": 29467}],
             # Second case, one new session with one known AS
-            [{"ip_address": ipaddress.ip_address("192.168.0.1"), "remote_asn": 29467}],
+            [{"ip_address": ipaddress.ip_address("192.0.2.1"), "remote_asn": 29467}],
             # Third case, new IPv4 session on another IX but with an IP that
             # has already been used
-            [{"ip_address": ipaddress.ip_address("192.168.0.1"), "remote_asn": 29467}],
+            [{"ip_address": ipaddress.ip_address("192.0.2.1"), "remote_asn": 29467}],
             # Fourth case, new IPv4 session with IPv6 prefix
-            [{"ip_address": ipaddress.ip_address("192.168.2.1"), "remote_asn": 29467}],
+            [{"ip_address": ipaddress.ip_address("203.0.113.1"), "remote_asn": 29467}],
         ]
 
         prefix_lists = [
             # First case
             [ipaddress.ip_network("2001:db8::/64")],
             # Second case
-            [ipaddress.ip_network("192.168.0.0/24")],
+            [ipaddress.ip_network("192.0.2.0/24")],
             # Third case
-            [ipaddress.ip_network("192.168.0.0/24")],
+            [ipaddress.ip_network("192.0.2.0/24")],
             # Fourth case
             [ipaddress.ip_network("2001:db8::/64")],
         ]
@@ -275,7 +275,7 @@ class InternetExchangePeeringSessionTest(TestCase):
         peering_session1 = InternetExchangePeeringSession.objects.create(
             autonomous_system=autonomous_system0,
             internet_exchange=internet_exchange0,
-            ip_address="192.168.1.1",
+            ip_address="198.51.100.1",
         )
 
         # Make sure that the session has been created
@@ -285,7 +285,7 @@ class InternetExchangePeeringSessionTest(TestCase):
         # Make sure we can retrieve the session with its IP
         self.assertEqual(
             peering_session1,
-            InternetExchangePeeringSession.does_exist(ip_address="192.168.1.1"),
+            InternetExchangePeeringSession.does_exist(ip_address="198.51.100.1"),
         )
         # Make sure it returns None when using a field that the two sessions
         # have in common
@@ -360,7 +360,7 @@ class RouterTest(TestCase):
             InternetExchangePeeringSession.objects.create(
                 autonomous_system=AutonomousSystem.objects.get(asn=i),
                 internet_exchange=internet_exchange,
-                ip_address="192.168.0.{}".format(i),
+                ip_address="192.0.2.{}".format(i),
             )
 
         # Convert to dict and merge values
@@ -457,28 +457,28 @@ class RouterTest(TestCase):
             None,
             {},
             # List size must match peers number including VRFs
-            {"global": {"peers": {"192.168.0.1": {"remote_as": 64500}}}},
+            {"global": {"peers": {"192.0.2.1": {"remote_as": 64500}}}},
             {
-                "global": {"peers": {"192.168.0.1": {"remote_as": 64500}}},
-                "vrf": {"peers": {"192.168.1.1": {"remote_as": 64501}}},
+                "global": {"peers": {"192.0.2.1": {"remote_as": 64500}}},
+                "vrf": {"peers": {"198.51.100.1": {"remote_as": 64501}}},
             },
             {
-                "global": {"peers": {"192.168.0.1": {"remote_as": 64500}}},
-                "vrf0": {"peers": {"192.168.1.1": {"remote_as": 64501}}},
-                "vrf1": {"peers": {"192.168.2.1": {"remote_as": 64502}}},
+                "global": {"peers": {"192.0.2.1": {"remote_as": 64500}}},
+                "vrf0": {"peers": {"198.51.100.1": {"remote_as": 64501}}},
+                "vrf1": {"peers": {"203.0.113.1": {"remote_as": 64502}}},
             },
             # If peer does not have remote_as field, it must be ignored
             {
-                "global": {"peers": {"192.168.0.1": {"remote_as": 64500}}},
-                "vrf0": {"peers": {"192.168.1.1": {"remote_as": 64501}}},
-                "vrf1": {"peers": {"192.168.2.1": {"not_valid": 64502}}},
+                "global": {"peers": {"192.0.2.1": {"remote_as": 64500}}},
+                "vrf0": {"peers": {"198.51.100.1": {"remote_as": 64501}}},
+                "vrf1": {"peers": {"203.0.113.1": {"not_valid": 64502}}},
             },
             # If an IP address appears more than one time, only the first
             # occurence  must be retained
             {
-                "global": {"peers": {"192.168.0.1": {"remote_as": 64500}}},
-                "vrf0": {"peers": {"192.168.1.1": {"remote_as": 64501}}},
-                "vrf1": {"peers": {"192.168.1.1": {"remote_as": 64502}}},
+                "global": {"peers": {"192.0.2.1": {"remote_as": 64500}}},
+                "vrf0": {"peers": {"198.51.100.1": {"remote_as": 64501}}},
+                "vrf1": {"peers": {"198.51.100.1": {"remote_as": 64502}}},
             },
         ]
 
@@ -500,7 +500,7 @@ class RouterTest(TestCase):
                 "up": True,
                 "local_as": 201281,
                 "remote_as": 29467,
-                "local_address": "192.168.1.1",
+                "local_address": "198.51.100.1",
             }
         ]
         bgp_neighbors_detail = {
@@ -510,7 +510,7 @@ class RouterTest(TestCase):
                         "up": True,
                         "local_as": 201281,
                         "remote_as": 29467,
-                        "local_address": "192.168.1.1",
+                        "local_address": "198.51.100.1",
                     }
                 ]
             }


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Peering Manager! Please
    indicate if your changes fix bugs or feature requests created in the issue
    tracker. This helps to avoid wasting time and effort to check for this
    before merging the code.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes:
 Addresses using documentation prefixes in tests and documentation as noted in #159.
<!--
    Please include a summary of the proposed changes below.
-->
