### PR TITLE
Be more liberal in what is accepted as an AS-SET

### DIFF
--- a/peering/__init__.py
+++ b/peering/__init__.py
@@ -68,7 +68,6 @@ def parse_irr_as_set(irr_as_set):
         if not value:
             continue
 
-        is_valid = True
         for regexp in [
             # Remove registry prefix if any
             r"^(?:{}):[:\s]".format(settings.BGPQ3_SOURCES.replace(",", "|")),
@@ -80,12 +79,7 @@ def parse_irr_as_set(irr_as_set):
             # If some substitutions have been made, make sure to clean things up
             if number_of_subs_made > 0:
                 value = value.strip()
-            # And reject a potential useless value
-            if not value or "AS-" not in value:
-                is_valid = False
 
-        # If AS-SET looks OK keep it to find prefix-list
-        if is_valid:
-            as_sets.append(value)
+        as_sets.append(value)
 
     return as_sets

--- a/peering/tests/test_functions.py
+++ b/peering/tests/test_functions.py
@@ -11,3 +11,6 @@ class IRRASSetFunctions(TestCase):
             parse_irr_as_set("RADB::AS-HURRICANE RADB::AS-HURRICANEv6"),
         )
         self.assertEqual(["AS51706:AS-MEMBERS"], parse_irr_as_set("AS51706:AS-MEMBERS"))
+        self.assertEqual(
+            ["AS3333:RS-CUSTOMERS"], parse_irr_as_set("AS3333:RS-CUSTOMERS")
+        )


### PR DESCRIPTION
While people usually use AS-xxxx for simple macros, when using
hierarchical macros, some are not always using "AS-" as a prefix for
each part. For example <https://www.peeringdb.com/net/2273> is using
AS16211:RS-ANNOUNCED which is invalid. However, there is little gain
of not accepting this macro as this makes the final configuration more
secure.

This commit removes the extra check about having AS- in the macro
name.