### PR TITLE
Remove unused imports

### DIFF
--- a/peering/forms.py
+++ b/peering/forms.py
@@ -1,5 +1,4 @@
 from django import forms
-from django.db.models import Q
 from django.conf import settings
 
 from taggit.forms import TagField
@@ -10,9 +9,6 @@ from .constants import (
     IP_FAMILY_CHOICES,
     PLATFORM_CHOICES,
     ROUTING_POLICY_TYPE_CHOICES,
-    ROUTING_POLICY_TYPE_EXPORT,
-    ROUTING_POLICY_TYPE_IMPORT,
-    ROUTING_POLICY_TYPE_IMPORT_EXPORT,
     TEMPLATE_TYPE_CHOICES,
 )
 from .models import (

--- a/peering/tables.py
+++ b/peering/tables.py
@@ -13,7 +13,6 @@ from .models import (
 )
 from peering_manager import settings
 from utils.tables import ActionsColumn, BaseTable, SelectColumn
-from utils.templatetags.helpers import markdown
 
 
 AUTONOMOUS_SYSTEM_ACTIONS = """

--- a/peering/views.py
+++ b/peering/views.py
@@ -3,12 +3,10 @@ from django.contrib import messages
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.core.mail import send_mail
 from django.db.models import Count
-from django.http import HttpResponseBadRequest, HttpResponse
-from django.shortcuts import get_object_or_404, redirect, render, reverse
+from django.http import HttpResponse
+from django.shortcuts import get_object_or_404, redirect, render
 from django.template.defaultfilters import slugify
 from django.views.generic import View
-
-import json
 
 from .constants import BGP_STATE_IDLE
 from .filters import (
@@ -85,7 +83,6 @@ from utils.views import (
     BulkAddFromDependencyView,
     BulkEditView,
     BulkDeleteView,
-    ConfirmationView,
     DeleteView,
     ModelListView,
     TableImportView,

--- a/peeringdb/views.py
+++ b/peeringdb/views.py
@@ -1,5 +1,4 @@
 from django.contrib import messages
-from django.contrib.auth.mixins import LoginRequiredMixin
 from django.shortcuts import redirect, render, reverse
 from django.views.generic import View
 

--- a/users/middleware.py
+++ b/users/middleware.py
@@ -1,5 +1,4 @@
 from django.conf import settings
-from django.urls import resolve
 
 
 class LastSearchMiddleware(object):

--- a/users/views.py
+++ b/users/views.py
@@ -1,5 +1,3 @@
-import sys
-
 from django.contrib import messages
 from django.contrib.auth import (
     login as auth_login,

--- a/utils/api/views.py
+++ b/utils/api/views.py
@@ -1,7 +1,5 @@
 from django.db.models import Count
 
-from rest_framework.viewsets import ViewSet
-
 from . import ModelViewSet
 from .serializers import TagSerializer
 from utils.filters import TagFilter

--- a/utils/crypto/junos.py
+++ b/utils/crypto/junos.py
@@ -1,5 +1,4 @@
 import random
-import sys
 
 
 # This code is the result of the attempt at converting a Perl module, the expected

--- a/utils/filters.py
+++ b/utils/filters.py
@@ -1,5 +1,4 @@
 import django_filters
-from taggit.forms import TagField
 
 from django.contrib.auth.models import User
 from django.db.models import Q

--- a/utils/middleware.py
+++ b/utils/middleware.py
@@ -1,4 +1,3 @@
-import sys
 import threading
 import uuid
 

--- a/utils/views.py
+++ b/utils/views.py
@@ -7,7 +7,7 @@ from django.db.models.query import QuerySet
 from django.contrib import messages
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.core.exceptions import ValidationError
-from django.forms import CharField, Form, MultipleHiddenInput
+from django.forms import CharField, MultipleHiddenInput
 from django.forms.formsets import formset_factory
 from django.http import HttpResponseServerError
 from django.shortcuts import get_object_or_404, redirect, render
@@ -25,7 +25,6 @@ from django_tables2 import RequestConfig
 
 from .filters import ObjectChangeFilter, TagFilter
 from .forms import (
-    BootstrapMixin,
     ConfirmationForm,
     FilterChoiceField,
     ObjectChangeFilterForm,


### PR DESCRIPTION
### Fixes:

Removes all unused imports throughout the project. Let me know if I missed something or if I removed too much. I found the unused imports using [LGTM](https://lgtm.com/projects/g/respawner/peering-manager/?mode=list) and verified manually as good as I could (and using `flake8`).