### PR TITLE
Fix typo in configure_routers.py

### DIFF
--- a/peering/management/commands/configure_routers.py
+++ b/peering/management/commands/configure_routers.py
@@ -19,7 +19,7 @@ class Command(BaseCommand):
             # is running on a supported platform
             if router.configuration_template and router.platform:
                 self.logger.info("Configuring {}".format(router.hostname))
-                # Generate configuration and apply it something has changed
+                # Generate configuration and apply it if something has changed
                 configuration = router.generate_configuration()
                 error, changes = router.set_napalm_configuration(configuration)
                 if not error and changes:


### PR DESCRIPTION
### Fixes:

Typo in a description under configure_routers.py.