### PR TITLE
Fix default timezone

### DIFF
--- a/docs/configuration/optional-settings.md
+++ b/docs/configuration/optional-settings.md
@@ -111,7 +111,8 @@ Determine how many objects to display per page within each list of objects.
 
 Default: `UTC`
 
-The time zone Peering Manager will for date and time operations.
+The time zone Peering Manager will for date and time operations. Peering Manager will
+also attempt to determine this value from `/etc/timezone` before defaulting to UTC.
 [List of available time zones](https://en.wikipedia.org/wiki/List_of_tz_database_time_zones).
 
 ---

--- a/peering_manager/settings.py
+++ b/peering_manager/settings.py
@@ -106,7 +106,14 @@ NAPALM_PASSWORD = getattr(configuration, "NAPALM_PASSWORD", "")
 NAPALM_TIMEOUT = getattr(configuration, "NAPALM_TIMEOUT", 30)
 NAPALM_ARGS = getattr(configuration, "NAPALM_ARGS", {})
 PAGINATE_COUNT = getattr(configuration, "PAGINATE_COUNT", 20)
-TIME_ZONE = getattr(configuration, "TIME_ZONE", "UTC")
+
+try:
+    TZ_FILE = open('/etc/timezone','r')
+    BASE_TZ = TZ_FILE.read()
+except IOError:
+    BASE_TZ = "UTC"
+
+TIME_ZONE = getattr(configuration, "TIME_ZONE", BASE_TZ)
 EMAIL = getattr(configuration, "EMAIL", {})
 BGPQ3_PATH = getattr(configuration, "BGPQ3_PATH", "bgpq3")
 BGPQ3_HOST = getattr(configuration, "BGPQ3_HOST", "rr.ntt.net")

--- a/peering_manager/settings.py
+++ b/peering_manager/settings.py
@@ -108,7 +108,7 @@ NAPALM_ARGS = getattr(configuration, "NAPALM_ARGS", {})
 PAGINATE_COUNT = getattr(configuration, "PAGINATE_COUNT", 20)
 
 try:
-    TZ_FILE = open('/etc/timezone','r')
+    TZ_FILE = open("/etc/timezone", "r")
     BASE_TZ = TZ_FILE.read()
 except IOError:
     BASE_TZ = "UTC"


### PR DESCRIPTION
### Fixes:

Introduces an attempt to obtain the local timezone from `/etc/timezone` prior to defaulting to UTC where TIME_ZONE is not specified.