### PR TITLE
New feature to allow building missing sessions for an AS

### DIFF
--- a/peering/models.py
+++ b/peering/models.py
@@ -280,7 +280,7 @@ class AutonomousSystem(ChangeLoggedModel, TaggableModel, TemplateModel):
             )
             .prefetch_related("network")
             .prefetch_related("network_ixlan")
-            .order_by("network_ixlan__name","network_ixlan__ipaddr6")
+            .order_by("network_ixlan__name", "network_ixlan__ipaddr6")
         )
 
     def synchronize_with_peeringdb(self):
@@ -1167,7 +1167,9 @@ class InternetExchangePeeringSession(BGPSession):
     def get_ix_list_for_peer_record(peer_record):
         ix_list = []
         # Find the Internet exchange given a NetworkIXLAN ID
-        for ix in InternetExchange.objects.exclude(peeringdb_id__isnull=True).exclude(peeringdb_id=0):
+        for ix in InternetExchange.objects.exclude(peeringdb_id__isnull=True).exclude(
+            peeringdb_id=0
+        ):
             # Get the IXLAN corresponding to our network
             try:
                 ixlan = NetworkIXLAN.objects.get(id=ix.peeringdb_id)
@@ -1189,8 +1191,6 @@ class InternetExchangePeeringSession(BGPSession):
                 ix_list.append(ix)
         return ix_list
 
-
-
     @staticmethod
     def create_from_peeringdb(peer_record, ip_version, internet_exchange=None):
         found_internet_exchange = None
@@ -1206,7 +1206,9 @@ class InternetExchangePeeringSession(BGPSession):
         if internet_exchange:
             found_internet_exchange = internet_exchange
         else:
-            ix_list = InternetExchangePeeringSession.get_ix_list_for_peer_record(peer_record)
+            ix_list = InternetExchangePeeringSession.get_ix_list_for_peer_record(
+                peer_record
+            )
             found_internet_exchange = ix_list[0]
 
         # Unable to find the Internet exchange, no point of going further

--- a/peering/models.py
+++ b/peering/models.py
@@ -268,6 +268,21 @@ class AutonomousSystem(ChangeLoggedModel, TaggableModel, TemplateModel):
 
         return ix_and_sessions
 
+    def get_available_sessions(self):
+        missing_sessions = self.potential_internet_exchange_peering_sessions
+
+        return (
+            PeerRecord.objects.filter(
+                (
+                    Q(network_ixlan__ipaddr6__in=missing_sessions)
+                    | Q(network_ixlan__ipaddr4__in=missing_sessions)
+                )
+            )
+            .prefetch_related("network")
+            .prefetch_related("network_ixlan")
+            .order_by("network_ixlan__name","network_ixlan__ipaddr6")
+        )
+
     def synchronize_with_peeringdb(self):
         """
         Synchronize AS properties with those found in PeeringDB.
@@ -1149,6 +1164,34 @@ class InternetExchangePeeringSession(BGPSession):
         ordering = ["autonomous_system", "ip_address"]
 
     @staticmethod
+    def get_ix_list_for_peer_record(peer_record):
+        ix_list = []
+        # Find the Internet exchange given a NetworkIXLAN ID
+        for ix in InternetExchange.objects.exclude(peeringdb_id__isnull=True).exclude(peeringdb_id=0):
+            # Get the IXLAN corresponding to our network
+            try:
+                ixlan = NetworkIXLAN.objects.get(id=ix.peeringdb_id)
+            except NetworkIXLAN.DoesNotExist:
+                InternetExchangePeeringSession.logger.debug(
+                    "NetworkIXLAN with ID {} not found, ignoring IX {}".format(
+                        ix.peeringdb_id, ix.name
+                    )
+                )
+                continue
+
+            # Get a potentially matching IXLAN
+            peer_ixlan = NetworkIXLAN.objects.filter(
+                id=peer_record.network_ixlan.id, ix_id=ixlan.ix_id
+            )
+
+            # IXLAN found lets get out
+            if peer_ixlan:
+                ix_list.append(ix)
+        return ix_list
+
+
+
+    @staticmethod
     def create_from_peeringdb(peer_record, ip_version, internet_exchange=None):
         found_internet_exchange = None
         peer_ixlan = None
@@ -1163,28 +1206,8 @@ class InternetExchangePeeringSession(BGPSession):
         if internet_exchange:
             found_internet_exchange = internet_exchange
         else:
-            # Find the Internet exchange given a NetworkIXLAN ID
-            for ix in InternetExchange.objects.exclude(peeringdb_id__isnull=True):
-                # Get the IXLAN corresponding to our network
-                try:
-                    ixlan = NetworkIXLAN.objects.get(id=ix.peeringdb_id)
-                except NetworkIXLAN.DoesNotExist:
-                    InternetExchangePeeringSession.logger.debug(
-                        "NetworkIXLAN with ID {} not found, ignoring IX {}".format(
-                            ix.peeringdb_id, ix.name
-                        )
-                    )
-                    continue
-
-                # Get a potentially matching IXLAN
-                peer_ixlan = NetworkIXLAN.objects.filter(
-                    id=peer_record.network_ixlan.id, ix_id=ixlan.ix_id
-                )
-
-                # IXLAN found lets get out
-                if peer_ixlan:
-                    found_internet_exchange = ix
-                    break
+            ix_list = InternetExchangePeeringSession.get_ix_list_for_peer_record(peer_record)
+            found_internet_exchange = ix_list[0]
 
         # Unable to find the Internet exchange, no point of going further
         if not found_internet_exchange:

--- a/peering/urls.py
+++ b/peering/urls.py
@@ -51,6 +51,16 @@ urlpatterns = [
         views.AutonomousSystemInternetExchangesPeeringSessions.as_view(),
         name="autonomoussystem_internet_exchange_peering_sessions",
     ),
+    re_path(
+        r"^autonomous-systems/(?P<asn>[0-9]+)/peers/$",
+        views.AutonomousSystemPeers.as_view(),
+        name="autonomoussystem_peers",
+    ),
+    re_path(
+        r"^autonomous-systems/add_from_peeringdb/$",
+        views.AutonomousSystemAddFromPeeringDB.as_view(),
+        name="autonomoussystem_add_from_peeringdb",
+    ),
     # BGP Groups
     re_path(r"^bgp-groups/$", views.BGPGroupList.as_view(), name="bgpgroup_list"),
     re_path(r"^bgp-groups/add/$", views.BGPGroupAdd.as_view(), name="bgpgroup_add"),

--- a/peering/views.py
+++ b/peering/views.py
@@ -312,6 +312,7 @@ class AutonomousSystemPeers(PermissionRequiredMixin, ModelListView):
             extra_context.update({"autonomous_system": autonomous_system})
         return extra_context
 
+
 class AutonomousSystemAddFromPeeringDB(
     PermissionRequiredMixin, BulkAddFromDependencyView
 ):
@@ -324,7 +325,9 @@ class AutonomousSystemAddFromPeeringDB(
     def process_dependency_object(self, request, dependency):
         return_value = []
 
-        for ix in InternetExchangePeeringSession.get_ix_list_for_peer_record(dependency):
+        for ix in InternetExchangePeeringSession.get_ix_list_for_peer_record(
+            dependency
+        ):
             (session6, created6) = InternetExchangePeeringSession.create_from_peeringdb(
                 dependency, 6, internet_exchange=ix
             )
@@ -353,7 +356,6 @@ class AutonomousSystemAddFromPeeringDB(
                     )
         return objects
 
-    
 
 class BGPGroupList(PermissionRequiredMixin, ModelListView):
     permission_required = "peering.view_bgpgroup"

--- a/peering/views.py
+++ b/peering/views.py
@@ -76,7 +76,7 @@ from peeringdb.filters import PeerRecordFilterSet
 from peeringdb.forms import PeerRecordFilterForm
 from peeringdb.http import PeeringDB
 from peeringdb.models import PeerRecord
-from peeringdb.tables import ContactTable, PeerRecordTable
+from peeringdb.tables import ContactTable, PeerRecordTable, ASPeerRecordTable
 from utils.views import (
     AddOrEditView,
     BulkAddFromDependencyView,
@@ -285,6 +285,75 @@ class AutonomousSystemInternetExchangesPeeringSessions(
 
         return extra_context
 
+
+class AutonomousSystemPeers(PermissionRequiredMixin, ModelListView):
+    permission_required = "peering.view_autonomoussystem"
+    filter = None
+    filter_form = None
+    table = ASPeerRecordTable
+    template = "peering/as/peers.html"
+
+    def build_queryset(self, request, kwargs):
+        # The queryset needs to be composed of PeerRecord objects but they are linked
+        # to an IX. So first of all we need to retrieve the IX on which we want to get
+        # the peering sessions.
+        if "asn" in kwargs:
+            autonomous_system = get_object_or_404(AutonomousSystem, asn=kwargs["asn"])
+            queryset = autonomous_system.get_available_sessions()
+
+        return queryset
+
+    def extra_context(self, kwargs):
+        extra_context = {}
+        # Since we are in the context of an AS we need to keep the reference
+        # for it
+        if "asn" in kwargs:
+            autonomous_system = get_object_or_404(AutonomousSystem, asn=kwargs["asn"])
+            extra_context.update({"autonomous_system": autonomous_system})
+        return extra_context
+
+class AutonomousSystemAddFromPeeringDB(
+    PermissionRequiredMixin, BulkAddFromDependencyView
+):
+    permission_required = "peering.add_internetexchangepeeringsession"
+    model = InternetExchangePeeringSession
+    dependency_model = PeerRecord
+    form_model = InternetExchangePeeringSessionForm
+    template = "peering/session/internet_exchange/add_from_peeringdb.html"
+
+    def process_dependency_object(self, request, dependency):
+        return_value = []
+
+        for ix in InternetExchangePeeringSession.get_ix_list_for_peer_record(dependency):
+            (session6, created6) = InternetExchangePeeringSession.create_from_peeringdb(
+                dependency, 6, internet_exchange=ix
+            )
+            (session4, created4) = InternetExchangePeeringSession.create_from_peeringdb(
+                dependency, 4, internet_exchange=ix
+            )
+
+            if session6 and created6:
+                return_value.append(session6)
+            if session4 and created4:
+                return_value.append(session4)
+
+        return return_value
+
+    def sort_objects(self, object_list):
+        objects = []
+        for object_couple in object_list:
+            for obj in object_couple:
+                if obj:
+                    objects.append(
+                        {
+                            "autonomous_system": obj.autonomous_system,
+                            "internet_exchange": obj.internet_exchange,
+                            "ip_address": obj.ip_address,
+                        }
+                    )
+        return objects
+
+    
 
 class BGPGroupList(PermissionRequiredMixin, ModelListView):
     permission_required = "peering.view_bgpgroup"

--- a/peeringdb/tables.py
+++ b/peeringdb/tables.py
@@ -55,3 +55,39 @@ class PeerRecordTable(BaseTable):
             "ipv6_address",
             "ipv4_address",
         )
+
+class ASPeerRecordTable(BaseTable):
+    """
+    Table for AS PeerRecord lists
+    """
+
+    empty_text = "No available peers found."
+    pk = SelectColumn()
+    ix = tables.Column(verbose_name="Internet Exchange", accessor="network_ixlan__name")
+    irr_as_set = tables.Column(
+        verbose_name="IRR AS-SET", accessor="network__irr_as_set", orderable=False
+    )
+    ipv6_max_prefixes = tables.Column(
+        verbose_name="IPv6", accessor="network__info_prefixes6"
+    )
+    ipv4_max_prefixes = tables.Column(
+        verbose_name="IPv4", accessor="network__info_prefixes4"
+    )
+    ipv6_address = tables.Column(
+        verbose_name="IPv6 Address", accessor="network_ixlan__ipaddr6"
+    )
+    ipv4_address = tables.Column(
+        verbose_name="IPv4 Address", accessor="network_ixlan__ipaddr4"
+    )
+
+    class Meta(BaseTable.Meta):
+        model = PeerRecord
+        fields = (
+            "pk",
+            "ix",
+            "irr_as_set",
+            "ipv6_max_prefixes",
+            "ipv4_max_prefixes",
+            "ipv6_address",
+            "ipv4_address",
+        )

--- a/peeringdb/tables.py
+++ b/peeringdb/tables.py
@@ -56,6 +56,7 @@ class PeerRecordTable(BaseTable):
             "ipv4_address",
         )
 
+
 class ASPeerRecordTable(BaseTable):
     """
     Table for AS PeerRecord lists

--- a/templates/peering/as/_base.html
+++ b/templates/peering/as/_base.html
@@ -35,6 +35,13 @@
           </a>
         </li>
         {% endif %}
+        {% if autonomous_system.potential_internet_exchange_peering_sessions|length > 0 %}
+        <li class="nav-item">
+          <a class="nav-link{% if request.path|contains:'/peers/' %} active{% endif %}" href="{% url 'peering:autonomoussystem_peers' asn=autonomous_system.asn %}">
+            <i class="fas fa-link"></i> Available Sessions
+          </a>
+        </li>
+        {% endif %}
         {% if autonomous_system.get_peeringdb_contacts|length > 0 %}
         <li class="nav-item">
           <a class="nav-link{% if request.path|contains:'/contacts/' %} active{% endif %}" href="{% url 'peering:autonomoussystem_contacts' asn=autonomous_system.asn %}">

--- a/templates/peering/as/peers.html
+++ b/templates/peering/as/peers.html
@@ -1,0 +1,11 @@
+{% extends 'peering/as/_base.html' %}
+{% block subcontent %}
+      <div class="row">
+        <div class="col-md-9">
+          {% include 'utils/object_list.html' with bulk_add_url='peering:autonomoussystem_add_from_peeringdb' bulk_edit_url='peeringdb:peer_record_bulk_edit' %}
+        </div>
+        <div class="col-md-3">
+          {% include 'utils/search_form.html' %}
+        </div>
+      </div>
+{% endblock %}


### PR DESCRIPTION
Added new tab to AS view where you can add missing sessions from in bulk
Based on the view for building missing sessions for an IX

<!--
    Thank you for your interest in contributing to Peering Manager! Please
    indicate if your changes fix bugs or feature requests created in the issue
    tracker. This helps to avoid wasting time and effort to check for this
    before merging the code.

    Please indicate the relevant feature request or bug report below.
-->
### Changes:
Adds 2 new views. One to display the missing sessions, another to receive the POST and build the form to review the changes. 

A new ASPeerRecordTable is defined since we want to display slightly different information than the original PeerRecordTable. 

New method for AutonomousSystems class that returns a query set of PeerRecords by matching the ipaddr6 and ipaddr4 with the missing_sessions list. 

New static method for InternetExchangePeeringSession to factor out the search for possible InternetExchange objects matching a PeerRecord. 

The missing sessions only shown once for each IX, even if you have multiple connections to the IX. However, these get expanded in the second view, although it is hard to tell which instance of the IX these are building it for unless the IX display names are unique. Maybe display the slug to make that clearer?