### PR TITLE
Fix list comparison in find_potential_ix_peering_sessions()

### DIFF
--- a/peering/models.py
+++ b/peering/models.py
@@ -178,15 +178,9 @@ class AutonomousSystem(ChangeLoggedModel, TaggableModel, TemplateModel):
             peering_sessions = []
 
             if peer.ipaddr6:
-                try:
-                    peering_sessions.append(str(ipaddress.IPv6Address(peer.ipaddr6)))
-                except ipaddress.AddressValueError:
-                    continue
+                peering_sessions.append(peer.ipaddr6)
             if peer.ipaddr4:
-                try:
-                    peering_sessions.append(str(ipaddress.IPv4Address(peer.ipaddr4)))
-                except ipaddress.AddressValueError:
-                    continue
+                peering_sessions.append(peer.ipaddr4)
 
             # Get all known sessions for this AS on the given IX
             known_sessions = InternetExchangePeeringSession.objects.filter(


### PR DESCRIPTION


<!--
    Thank you for your interest in contributing to Peering Manager! Please
    indicate if your changes fix bugs or feature requests created in the issue
    tracker. This helps to avoid wasting time and effort to check for this
    before merging the code.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes:
In find_potential_ix_peering_sessions() network_ixlan.ipaddr6/ipaddr4 fields were being cast to IPv4/6Address objects and back to string again unnecesarily, which was causing the list comparison to always fail and constantly update the potential_internet_exchange_peering_sessions field. Since the ipaddr6/ipaddr4 fields are already the right type, they can just be added directly to the list

<!--
    Please include a summary of the proposed changes below.
-->
