### PR TITLE
Use Redis as cache

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -8,9 +8,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.8
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -46,10 +46,14 @@ jobs:
           POSTGRES_DB: peering_manager
           POSTGRES_USER: devbox
           POSTGRES_PASSWORD: devbox
+      redis:
+        image: redis:6.0
+        ports:
+          - 6379:6379
     steps:
       - uses: actions/checkout@v2
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,4 @@ static
 logs/*
 !logs/.gitkeep
 scripts/development/postgresql
+scripts/development/redis

--- a/docs/configuration/optional-settings.md
+++ b/docs/configuration/optional-settings.md
@@ -35,6 +35,44 @@ for more information on configuring this setting.
 
 ---
 
+## REDIS
+
+[Redis](https://redis.io/) is an in-memory data store similar to memcached. It
+is required to support caching functionality .
+
+Redis is configured using a configuration setting similar to `DATABASE`:
+
+* `HOST` - Name or IP address of the Redis server (use `localhost` if running locally)
+* `PORT` - TCP port of the Redis service; leave blank for default port (6379)
+* `PASSWORD` - Redis password (if set)
+* `CACHE_DATABASE` - Numeric database ID for caching
+* `DEFAULT_TIMEOUT` - Connection timeout in seconds
+* `SSL` - Use SSL connection to Redis
+
+Example:
+
+```
+REDIS = {
+    'HOST': 'localhost',
+    'PORT': 6379,
+    'PASSWORD': '',
+    'CACHE_DATABASE': 1,
+    'DEFAULT_TIMEOUT': 300,
+    'SSL': False,
+}
+```
+
+---
+
+## CACHE_TIMEOUT
+
+Default: 0
+
+The number of seconds to retain cache entries before automatically invalidating
+them. Setting the value to 0 will disable the use of the caching functionality.
+
+---
+
 ## CHANGELOG_RETENTION
 
 Default: `90`

--- a/peering/tables.py
+++ b/peering/tables.py
@@ -355,4 +355,4 @@ class TemplateTable(BaseTable):
 
     class Meta(BaseTable.Meta):
         model = Template
-        fields = ("pk", "type", "name", "updated", "actions")
+        fields = ("pk", "name", "type", "updated", "actions")

--- a/peering/views.py
+++ b/peering/views.py
@@ -604,7 +604,7 @@ class DirectPeeringSessionList(PermissionRequiredMixin, ModelListView):
 
 class InternetExchangeList(PermissionRequiredMixin, ModelListView):
     permission_required = "peering.view_internetexchange"
-    queryset = InternetExchange.objects.prefetch_related("autonomous_system").order_by(
+    queryset = InternetExchange.objects.prefetch_related("router").order_by(
         "name", "slug"
     )
     table = InternetExchangeTable

--- a/peering/views.py
+++ b/peering/views.py
@@ -604,7 +604,9 @@ class DirectPeeringSessionList(PermissionRequiredMixin, ModelListView):
 
 class InternetExchangeList(PermissionRequiredMixin, ModelListView):
     permission_required = "peering.view_internetexchange"
-    queryset = InternetExchange.objects.order_by("name", "slug")
+    queryset = InternetExchange.objects.prefetch_related("autonomous_system").order_by(
+        "name", "slug"
+    )
     table = InternetExchangeTable
     filter = InternetExchangeFilterSet
     filter_form = InternetExchangeFilterForm
@@ -925,7 +927,7 @@ class InternetExchangePeeringSessionBulkDelete(PermissionRequiredMixin, BulkDele
 
 class RouterList(PermissionRequiredMixin, ModelListView):
     permission_required = "peering.view_router"
-    queryset = Router.objects.all()
+    queryset = Router.objects.prefetch_related("configuration_template").all()
     filter = RouterFilterSet
     filter_form = RouterFilterForm
     table = RouterTable

--- a/peering/views.py
+++ b/peering/views.py
@@ -270,7 +270,9 @@ class AutonomousSystemInternetExchangesPeeringSessions(
         # which we want to get the peering sessions.
         if "asn" in kwargs:
             autonomous_system = get_object_or_404(AutonomousSystem, asn=kwargs["asn"])
-            queryset = autonomous_system.internetexchangepeeringsession_set.order_by(
+            queryset = autonomous_system.internetexchangepeeringsession_set.prefetch_related(
+                "internet_exchange"
+            ).order_by(
                 "internet_exchange", "ip_address"
             )
 
@@ -428,9 +430,9 @@ class BGPGroupPeeringSessions(PermissionRequiredMixin, ModelListView):
         queryset = None
         if "slug" in kwargs:
             bgp_group = get_object_or_404(BGPGroup, slug=kwargs["slug"])
-            queryset = bgp_group.directpeeringsession_set.order_by(
-                "autonomous_system", "ip_address"
-            )
+            queryset = bgp_group.directpeeringsession_set.prefetch_related(
+                "autonomous_system", "router"
+            ).order_by("autonomous_system", "ip_address")
         return queryset
 
     def extra_context(self, kwargs):
@@ -724,7 +726,9 @@ class InternetExchangePeeringSessions(PermissionRequiredMixin, ModelListView):
         # which we want to get the peering sessions.
         if "slug" in kwargs:
             internet_exchange = get_object_or_404(InternetExchange, slug=kwargs["slug"])
-            queryset = internet_exchange.internetexchangepeeringsession_set.order_by(
+            queryset = internet_exchange.internetexchangepeeringsession_set.prefetch_related(
+                "autonomous_system"
+            ).order_by(
                 "autonomous_system", "ip_address"
             )
 

--- a/peering_manager/configuration.example.py
+++ b/peering_manager/configuration.example.py
@@ -25,3 +25,16 @@ DATABASE = {
     "HOST": "localhost",  # Database server
     "PORT": "",  # Database port (leave blank for default)
 }
+
+# Redis configuration
+REDIS = {
+    "HOST": "localhost",
+    "PORT": 6379,
+    "PASSWORD": "",
+    "CACHE_DATABASE": 1,
+    "DEFAULT_TIMEOUT": 300,
+    "SSL": False,
+}
+
+# Cache timeout in seconds. Set ti 0 to disable caching.
+CACHE_TIMEOUT = 900

--- a/peering_manager/configuration.example.py
+++ b/peering_manager/configuration.example.py
@@ -36,5 +36,5 @@ REDIS = {
     "SSL": False,
 }
 
-# Cache timeout in seconds. Set ti 0 to disable caching.
+# Cache timeout in seconds. Set to 0 to disable caching.
 CACHE_TIMEOUT = 900

--- a/peering_manager/settings.py
+++ b/peering_manager/settings.py
@@ -83,14 +83,17 @@ except ImportError:
         "Configuration file is not present. Please define peering_manager/configuration.py per the documentation."
     )
 
-DATABASE = SECRET_KEY = ALLOWED_HOSTS = MY_ASN = None
-for setting in ["DATABASE", "SECRET_KEY", "ALLOWED_HOSTS", "MY_ASN"]:
-    try:
-        globals()[setting] = getattr(configuration, setting)
-    except AttributeError:
+for setting in ["ALLOWED_HOSTS", "DATABASE", "SECRET_KEY", "MY_ASN"]:
+    if not hasattr(configuration, setting):
         raise ImproperlyConfigured(
             "Mandatory setting {} is not in the configuration.py file.".format(setting)
         )
+
+# Set required parameters
+ALLOWED_HOSTS = getattr(configuration, "ALLOWED_HOSTS")
+DATABASE = getattr(configuration, "DATABASE")
+SECRET_KEY = getattr(configuration, "SECRET_KEY")
+MY_ASN = getattr(configuration, "MY_ASN")
 
 CSRF_TRUSTED_ORIGINS = ALLOWED_HOSTS
 

--- a/peering_manager/settings.py
+++ b/peering_manager/settings.py
@@ -244,6 +244,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "cacheops",
     "django_filters",
     "django_tables2",
     "rest_framework",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Django>=3.0,<3.1
+django-cacheops==4.2
 djangorestframework==3.11.0
 django-filter==2.2.0
 django-netfields==1.2.2

--- a/scripts/development/dev-stack.yml
+++ b/scripts/development/dev-stack.yml
@@ -13,6 +13,14 @@ services:
     ports:
       - 5432:5432
 
+  cache:
+    image: redis:5.0-alpine
+    volumes:
+      - ./redis/data:/data
+    restart: always
+    ports:
+      - 6379:6379
+
   adminer:
     image: adminer
     restart: always

--- a/scripts/development/dev-stack.yml
+++ b/scripts/development/dev-stack.yml
@@ -14,7 +14,7 @@ services:
       - 5432:5432
 
   cache:
-    image: redis:5.0-alpine
+    image: redis:6.0-alpine
     volumes:
       - ./redis/data:/data
     restart: always


### PR DESCRIPTION
Use Redis as cache to speed data retrieval and reduce the number of SQL queries to be performed in a multi-users environment.

Some views can be quite expensive to load due to heavy SQL queries. Caching results of queries into Redis will speed views rendering by avoiding SQL queries that we already executed.

This add `django-cacheops` as a dependency, though the use of Redis is not yet required. It probably will be at some points to add more features.