### PR TITLE
Leverage API driven select element

### DIFF
--- a/peering/forms.py
+++ b/peering/forms.py
@@ -35,7 +35,8 @@ from utils.forms import (
     BulkEditForm,
     BootstrapMixin,
     CustomNullBooleanSelect,
-    FilterChoiceField,
+    DynamicModelChoiceField,
+    DynamicModelMultipleChoiceField,
     SmallTextarea,
     StaticSelect,
     StaticSelectMultiple,
@@ -59,21 +60,15 @@ class TemplateField(TextareaField):
 
 
 class AutonomousSystemForm(BootstrapMixin, forms.ModelForm):
-    import_routing_policies = FilterChoiceField(
+    import_routing_policies = DynamicModelMultipleChoiceField(
         required=False,
         queryset=RoutingPolicy.objects.all(),
-        widget=APISelectMultiple(
-            api_url="/api/peering/routing-policies/",
-            query_filters={"type": "import-policy"},
-        ),
+        widget=APISelectMultiple(additional_query_params={"type": "import-policy"}),
     )
-    export_routing_policies = FilterChoiceField(
+    export_routing_policies = DynamicModelMultipleChoiceField(
         required=False,
         queryset=RoutingPolicy.objects.all(),
-        widget=APISelectMultiple(
-            api_url="/api/peering/routing-policies/",
-            query_filters={"type": "export-policy"},
-        ),
+        widget=APISelectMultiple(additional_query_params={"type": "export-policy"}),
     )
     comments = CommentField()
     tags = TagField(required=False)
@@ -125,11 +120,9 @@ class AutonomousSystemFilterForm(BootstrapMixin, forms.Form):
 
 
 class AutonomousSystemEmailForm(BootstrapMixin, forms.Form):
-    template = forms.ModelChoiceField(
+    template = DynamicModelChoiceField(
         queryset=Template.objects.all(),
-        widget=APISelect(
-            api_url="/api/peering/templates/", query_filters={"type": "email"}
-        ),
+        widget=APISelect(additional_query_params={"type": "email"}),
     )
     recipient = forms.ChoiceField(widget=StaticSelect, label="E-mail Recipient")
     subject = forms.CharField(label="E-mail Subject")
@@ -139,26 +132,18 @@ class AutonomousSystemEmailForm(BootstrapMixin, forms.Form):
 class BGPGroupForm(BootstrapMixin, forms.ModelForm):
     slug = SlugField(max_length=255)
     comments = CommentField()
-    import_routing_policies = FilterChoiceField(
+    import_routing_policies = DynamicModelMultipleChoiceField(
         required=False,
         queryset=RoutingPolicy.objects.all(),
-        widget=APISelectMultiple(
-            api_url="/api/peering/routing-policies/",
-            query_filters={"type": "import-policy"},
-        ),
+        widget=APISelectMultiple(additional_query_params={"type": "import-policy"}),
     )
-    export_routing_policies = FilterChoiceField(
+    export_routing_policies = DynamicModelMultipleChoiceField(
         required=False,
         queryset=RoutingPolicy.objects.all(),
-        widget=APISelectMultiple(
-            api_url="/api/peering/routing-policies/",
-            query_filters={"type": "export-policy"},
-        ),
+        widget=APISelectMultiple(additional_query_params={"type": "export-policy"}),
     )
-    communities = FilterChoiceField(
-        required=False,
-        queryset=Community.objects.all(),
-        widget=APISelectMultiple(api_url="/api/peering/communities/"),
+    communities = DynamicModelMultipleChoiceField(
+        required=False, queryset=Community.objects.all()
     )
     tags = TagField(required=False)
 
@@ -182,29 +167,21 @@ class BGPGroupForm(BootstrapMixin, forms.ModelForm):
 
 
 class BGPGroupBulkEditForm(BootstrapMixin, AddRemoveTagsForm, BulkEditForm):
-    pk = FilterChoiceField(
+    pk = DynamicModelMultipleChoiceField(
         queryset=BGPGroup.objects.all(), widget=forms.MultipleHiddenInput
     )
-    import_routing_policies = FilterChoiceField(
+    import_routing_policies = DynamicModelMultipleChoiceField(
         required=False,
         queryset=RoutingPolicy.objects.all(),
-        widget=APISelectMultiple(
-            api_url="/api/peering/routing-policies/",
-            query_filters={"type": "import-policy"},
-        ),
+        widget=APISelectMultiple(additional_query_params={"type": "import-policy"}),
     )
-    export_routing_policies = FilterChoiceField(
+    export_routing_policies = DynamicModelMultipleChoiceField(
         required=False,
         queryset=RoutingPolicy.objects.all(),
-        widget=APISelectMultiple(
-            api_url="/api/peering/routing-policies/",
-            query_filters={"type": "export-policy"},
-        ),
+        widget=APISelectMultiple(additional_query_params={"type": "export-policy"}),
     )
-    communities = FilterChoiceField(
-        required=False,
-        queryset=Community.objects.all(),
-        widget=APISelectMultiple(api_url="/api/peering/communities/"),
+    communities = DynamicModelMultipleChoiceField(
+        required=False, queryset=Community.objects.all()
     )
     comments = CommentField(widget=SmallTextarea)
 
@@ -238,7 +215,7 @@ class CommunityForm(BootstrapMixin, forms.ModelForm):
 
 
 class CommunityBulkEditForm(BootstrapMixin, AddRemoveTagsForm, BulkEditForm):
-    pk = FilterChoiceField(
+    pk = DynamicModelMultipleChoiceField(
         queryset=Community.objects.all(), widget=forms.MultipleHiddenInput
     )
     type = forms.ChoiceField(
@@ -268,40 +245,29 @@ class DirectPeeringSessionForm(BootstrapMixin, forms.ModelForm):
         label="Local ASN",
         help_text=f"ASN to be used locally, defaults to {settings.MY_ASN}",
     )
-    autonomous_system = forms.ModelChoiceField(
-        queryset=AutonomousSystem.objects.all(),
-        label="Autonomous System",
-        widget=APISelect(api_url="/api/peering/autonomous-systems/"),
+    autonomous_system = DynamicModelChoiceField(
+        queryset=AutonomousSystem.objects.all(), label="Autonomous System"
     )
-    bgp_group = forms.ModelChoiceField(
-        required=False,
-        queryset=BGPGroup.objects.all(),
-        label="BGP Group",
-        widget=APISelect(api_url="/api/peering/bgp-groups/"),
+    bgp_group = DynamicModelChoiceField(
+        required=False, queryset=BGPGroup.objects.all(), label="BGP Group"
     )
     relationship = forms.ChoiceField(
         choices=BGP_RELATIONSHIP_CHOICES, widget=StaticSelect
     )
-    router = forms.ModelChoiceField(
+    router = DynamicModelChoiceField(
         required=False,
         queryset=Router.objects.all(),
-        widget=APISelect(api_url="/api/peering/routers/"),
+        help_text="Router on which this session is configured",
     )
-    import_routing_policies = FilterChoiceField(
+    import_routing_policies = DynamicModelMultipleChoiceField(
         required=False,
         queryset=RoutingPolicy.objects.all(),
-        widget=APISelectMultiple(
-            api_url="/api/peering/routing-policies/",
-            query_filters={"type": "import-policy"},
-        ),
+        widget=APISelectMultiple(additional_query_params={"type": "import-policy"}),
     )
-    export_routing_policies = FilterChoiceField(
+    export_routing_policies = DynamicModelMultipleChoiceField(
         required=False,
         queryset=RoutingPolicy.objects.all(),
-        widget=APISelectMultiple(
-            api_url="/api/peering/routing-policies/",
-            query_filters={"type": "export-policy"},
-        ),
+        widget=APISelectMultiple(additional_query_params={"type": "export-policy"}),
     )
     password = PasswordField(required=False, render_value=True)
     comments = CommentField()
@@ -330,21 +296,17 @@ class DirectPeeringSessionForm(BootstrapMixin, forms.ModelForm):
             "local_ip_address": "IPv6 or IPv4 address",
             "ip_address": "IPv6 or IPv4 address",
             "enabled": "Should this session be enabled?",
-            "router": "Router on which this session is configured",
         }
 
     def __init__(self, *args, **kwargs):
-        initial = kwargs.get("initial", None)
-        updated = {}
-        if initial:
-            updated["autonomous_system"] = initial.get("autonomous_system", None)
-        updated["local_asn"] = settings.MY_ASN
-        kwargs.update(initial=updated)
+        initial = kwargs.get("initial", {})
+        # Set local ASN according to the one found in the settings
+        initial.update({"local_asn": settings.MY_ASN})
         super().__init__(*args, **kwargs)
 
 
 class DirectPeeringSessionBulkEditForm(BootstrapMixin, AddRemoveTagsForm, BulkEditForm):
-    pk = FilterChoiceField(
+    pk = DynamicModelMultipleChoiceField(
         queryset=DirectPeeringSession.objects.all(), widget=forms.MultipleHiddenInput
     )
     enabled = forms.NullBooleanField(
@@ -355,33 +317,20 @@ class DirectPeeringSessionBulkEditForm(BootstrapMixin, AddRemoveTagsForm, BulkEd
         choices=add_blank_choice(BGP_RELATIONSHIP_CHOICES),
         widget=StaticSelect,
     )
-    bgp_group = forms.ModelChoiceField(
-        required=False,
-        queryset=BGPGroup.objects.all(),
-        label="BGP Group",
-        widget=APISelect(api_url="/api/peering/bgp-groups/"),
+    bgp_group = DynamicModelChoiceField(
+        required=False, queryset=BGPGroup.objects.all(), label="BGP Group"
     )
-    import_routing_policies = FilterChoiceField(
+    import_routing_policies = DynamicModelMultipleChoiceField(
         required=False,
         queryset=RoutingPolicy.objects.all(),
-        widget=APISelectMultiple(
-            api_url="/api/peering/routing-policies/",
-            query_filters={"type": "import-policy"},
-        ),
+        widget=APISelectMultiple(additional_query_params={"type": "import-policy"}),
     )
-    export_routing_policies = FilterChoiceField(
+    export_routing_policies = DynamicModelMultipleChoiceField(
         required=False,
         queryset=RoutingPolicy.objects.all(),
-        widget=APISelectMultiple(
-            api_url="/api/peering/routing-policies/",
-            query_filters={"type": "export-policy"},
-        ),
+        widget=APISelectMultiple(additional_query_params={"type": "export-policy"}),
     )
-    router = forms.ModelChoiceField(
-        required=False,
-        queryset=Router.objects.all(),
-        widget=APISelect(api_url="/api/peering/routers/"),
-    )
+    router = DynamicModelChoiceField(required=False, queryset=Router.objects.all())
     comments = CommentField()
 
     class Meta:
@@ -397,12 +346,11 @@ class DirectPeeringSessionFilterForm(BootstrapMixin, forms.Form):
     model = DirectPeeringSession
     q = forms.CharField(required=False, label="Search")
     local_asn = forms.IntegerField(required=False, label="Local ASN")
-    bgp_group = FilterChoiceField(
+    bgp_group = DynamicModelMultipleChoiceField(
         queryset=BGPGroup.objects.all(),
         to_field_name="pk",
-        null_label=True,
         label="BGP Group",
-        widget=APISelectMultiple(api_url="/api/peering/bgp-groups/", null_option=True),
+        widget=APISelectMultiple(null_option=True),
     )
     address_family = forms.ChoiceField(
         required=False, choices=IP_FAMILY_CHOICES, widget=StaticSelect
@@ -413,37 +361,33 @@ class DirectPeeringSessionFilterForm(BootstrapMixin, forms.Form):
     relationship = forms.MultipleChoiceField(
         required=False, choices=BGP_RELATIONSHIP_CHOICES, widget=StaticSelectMultiple
     )
-    router = FilterChoiceField(
+    router = DynamicModelMultipleChoiceField(
         queryset=Router.objects.all(),
         to_field_name="pk",
-        null_label=True,
-        widget=APISelectMultiple(api_url="/api/peering/routers/", null_option=True),
+        widget=APISelectMultiple(null_option=True),
     )
     tag = TagFilterField(model)
 
 
 class InternetExchangeForm(BootstrapMixin, forms.ModelForm):
     slug = SlugField(max_length=255)
-    import_routing_policies = FilterChoiceField(
+    import_routing_policies = DynamicModelMultipleChoiceField(
         required=False,
         queryset=RoutingPolicy.objects.all(),
-        widget=APISelectMultiple(
-            api_url="/api/peering/routing-policies/",
-            query_filters={"type": "import-policy"},
-        ),
+        widget=APISelectMultiple(additional_query_params={"type": "import-policy"}),
     )
-    export_routing_policies = FilterChoiceField(
+    export_routing_policies = DynamicModelMultipleChoiceField(
         required=False,
         queryset=RoutingPolicy.objects.all(),
-        widget=APISelectMultiple(
-            api_url="/api/peering/routing-policies/",
-            query_filters={"type": "export-policy"},
-        ),
+        widget=APISelectMultiple(additional_query_params={"type": "export-policy"}),
     )
-    communities = FilterChoiceField(
+    communities = DynamicModelMultipleChoiceField(
+        required=False, queryset=Community.objects.all()
+    )
+    router = DynamicModelChoiceField(
         required=False,
-        queryset=Community.objects.all(),
-        widget=APISelectMultiple(api_url="/api/peering/communities/"),
+        queryset=Router.objects.all(),
+        help_text="Router connected to the Internet Exchange point",
     )
     comments = CommentField()
     tags = TagField(required=False)
@@ -475,45 +419,31 @@ class InternetExchangeForm(BootstrapMixin, forms.ModelForm):
             "name": "Full name of the Internet Exchange point",
             "ipv6_address": "IPv6 Address used to peer",
             "ipv4_address": "IPv4 Address used to peer",
-            "router": "Router connected to the Internet Exchange point",
             "check_bgp_session_states": "If enabled, with a usable router, the state of peering sessions will be polled.",
         }
-        widgets = {"router": APISelect(api_url="/api/peering/routers/")}
 
 
 class InternetExchangeBulkEditForm(BootstrapMixin, AddRemoveTagsForm, BulkEditForm):
-    pk = FilterChoiceField(
+    pk = DynamicModelMultipleChoiceField(
         queryset=InternetExchange.objects.all(), widget=forms.MultipleHiddenInput
     )
-    import_routing_policies = FilterChoiceField(
+    import_routing_policies = DynamicModelMultipleChoiceField(
         required=False,
         queryset=RoutingPolicy.objects.all(),
-        widget=APISelectMultiple(
-            api_url="/api/peering/routing-policies/",
-            query_filters={"type": "import-policy"},
-        ),
+        widget=APISelectMultiple(additional_query_params={"type": "import-policy"}),
     )
-    export_routing_policies = FilterChoiceField(
+    export_routing_policies = DynamicModelMultipleChoiceField(
         required=False,
         queryset=RoutingPolicy.objects.all(),
-        widget=APISelectMultiple(
-            api_url="/api/peering/routing-policies/",
-            query_filters={"type": "export-policy"},
-        ),
+        widget=APISelectMultiple(additional_query_params={"type": "export-policy"}),
     )
-    communities = FilterChoiceField(
-        required=False,
-        queryset=Community.objects.all(),
-        widget=APISelectMultiple(api_url="/api/peering/communities/"),
-    )
-    router = forms.ModelChoiceField(
-        required=False,
-        queryset=Router.objects.all(),
-        widget=APISelect(api_url="/api/peering/routers/"),
+    communities = DynamicModelMultipleChoiceField(
+        required=False, queryset=Community.objects.all()
     )
     check_bgp_session_states = forms.NullBooleanField(
         required=False, label="Poll BGP State", widget=CustomNullBooleanSelect
     )
+    router = DynamicModelChoiceField(required=False, queryset=Router.objects.all())
     comments = CommentField(widget=SmallTextarea)
 
     class Meta:
@@ -568,31 +498,27 @@ class InternetExchangePeeringDBFormSet(forms.BaseFormSet):
 class InternetExchangeFilterForm(BootstrapMixin, forms.Form):
     model = InternetExchange
     q = forms.CharField(required=False, label="Search")
-    import_routing_policies = FilterChoiceField(
+    import_routing_policies = DynamicModelMultipleChoiceField(
+        required=False,
         queryset=RoutingPolicy.objects.all(),
         to_field_name="pk",
-        null_label=True,
         widget=APISelectMultiple(
-            api_url="/api/peering/routing-policies/",
-            query_filters={"type": "import-policy"},
-            null_option=True,
+            additional_query_params={"type": "import-policy"}, null_option=True
         ),
     )
-    export_routing_policies = FilterChoiceField(
+    export_routing_policies = DynamicModelMultipleChoiceField(
+        required=False,
         queryset=RoutingPolicy.objects.all(),
         to_field_name="pk",
-        null_label=True,
         widget=APISelectMultiple(
-            api_url="/api/peering/routing-policies/",
-            query_filters={"type": "export-policy"},
-            null_option=True,
+            additional_query_params={"type": "export-policy"}, null_option=True
         ),
     )
-    router = FilterChoiceField(
+    router = DynamicModelMultipleChoiceField(
+        required=False,
         queryset=Router.objects.all(),
         to_field_name="pk",
-        null_label=True,
-        widget=APISelectMultiple(api_url="/api/peering/routers/", null_option=True),
+        widget=APISelectMultiple(null_option=True),
     )
     tag = TagFilterField(model)
 
@@ -600,7 +526,7 @@ class InternetExchangeFilterForm(BootstrapMixin, forms.Form):
 class InternetExchangePeeringSessionBulkEditForm(
     BootstrapMixin, AddRemoveTagsForm, BulkEditForm
 ):
-    pk = FilterChoiceField(
+    pk = DynamicModelMultipleChoiceField(
         queryset=InternetExchangePeeringSession.objects.all(),
         widget=forms.MultipleHiddenInput,
     )
@@ -610,21 +536,15 @@ class InternetExchangePeeringSessionBulkEditForm(
     enabled = forms.NullBooleanField(
         required=False, label="Enable", widget=CustomNullBooleanSelect
     )
-    import_routing_policies = FilterChoiceField(
+    import_routing_policies = DynamicModelMultipleChoiceField(
         required=False,
         queryset=RoutingPolicy.objects.all(),
-        widget=APISelectMultiple(
-            api_url="/api/peering/routing-policies/",
-            query_filters={"type": "import-policy"},
-        ),
+        widget=APISelectMultiple(additional_query_params={"type": "import-policy"}),
     )
-    export_routing_policies = FilterChoiceField(
+    export_routing_policies = DynamicModelMultipleChoiceField(
         required=False,
         queryset=RoutingPolicy.objects.all(),
-        widget=APISelectMultiple(
-            api_url="/api/peering/routing-policies/",
-            query_filters={"type": "export-policy"},
-        ),
+        widget=APISelectMultiple(additional_query_params={"type": "export-policy"}),
     )
     comments = CommentField(widget=SmallTextarea)
 
@@ -637,33 +557,25 @@ class InternetExchangePeeringSessionBulkEditForm(
 
 
 class InternetExchangePeeringSessionForm(BootstrapMixin, forms.ModelForm):
-    autonomous_system = forms.ModelChoiceField(
-        queryset=AutonomousSystem.objects.all(),
-        label="Autonomous System",
-        widget=APISelect(api_url="/api/peering/autonomous-systems/"),
+    autonomous_system = DynamicModelChoiceField(
+        queryset=AutonomousSystem.objects.all(), label="Autonomous System"
+    )
+    internet_exchange = DynamicModelChoiceField(
+        queryset=InternetExchange.objects.all(), label="Internet Exchange"
     )
     password = PasswordField(required=False, render_value=True)
-    import_routing_policies = FilterChoiceField(
+    import_routing_policies = DynamicModelMultipleChoiceField(
         required=False,
         queryset=RoutingPolicy.objects.all(),
-        widget=APISelectMultiple(
-            api_url="/api/peering/routing-policies/",
-            query_filters={"type": "import-policy"},
-        ),
+        widget=APISelectMultiple(additional_query_params={"type": "import-policy"}),
     )
-    export_routing_policies = FilterChoiceField(
+    export_routing_policies = DynamicModelMultipleChoiceField(
         required=False,
         queryset=RoutingPolicy.objects.all(),
-        widget=APISelectMultiple(
-            api_url="/api/peering/routing-policies/",
-            query_filters={"type": "export-policy"},
-        ),
+        widget=APISelectMultiple(additional_query_params={"type": "export-policy"}),
     )
     comments = CommentField()
     tags = TagField(required=False)
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
 
     class Meta:
         model = InternetExchangePeeringSession
@@ -680,37 +592,27 @@ class InternetExchangePeeringSessionForm(BootstrapMixin, forms.ModelForm):
             "comments",
             "tags",
         )
-        labels = {
-            "internet_exchange": "Internet Exchange",
-            "ip_address": "IP Address",
-            "is_route_server": "Route Server",
-        }
+        labels = {"ip_address": "IP Address", "is_route_server": "Route Server"}
         help_texts = {
             "ip_address": "IPv6 or IPv4 address",
             "is_route_server": "Define if this session is with a route server",
-        }
-        widgets = {
-            "autonomous_system": APISelect(api_url="/api/peering/autonomous-systems/"),
-            "internet_exchange": APISelect(api_url="/api/peering/internet-exchanges/"),
         }
 
 
 class InternetExchangePeeringSessionFilterForm(BootstrapMixin, forms.Form):
     model = InternetExchangePeeringSession
     q = forms.CharField(required=False, label="Search")
-    autonomous_system__id = FilterChoiceField(
+    autonomous_system__id = DynamicModelMultipleChoiceField(
+        required=False,
         queryset=AutonomousSystem.objects.all(),
         to_field_name="pk",
         label="Autonomous System",
-        null_label=True,
-        widget=APISelectMultiple(api_url="/api/peering/autonomous-systems/"),
     )
-    internet_exchange__id = FilterChoiceField(
+    internet_exchange__id = DynamicModelMultipleChoiceField(
+        required=False,
         queryset=InternetExchange.objects.all(),
         to_field_name="pk",
         label="Internet Exchange",
-        null_label=True,
-        widget=APISelectMultiple(api_url="/api/peering/internet-exchanges/"),
     )
     address_family = forms.ChoiceField(
         required=False, choices=IP_FAMILY_CHOICES, widget=StaticSelect
@@ -728,6 +630,13 @@ class RouterForm(BootstrapMixin, forms.ModelForm):
     netbox_device_id = forms.IntegerField(label="NetBox Device", initial=0)
     platform = forms.ChoiceField(
         required=False, choices=add_blank_choice(PLATFORM_CHOICES), widget=StaticSelect
+    )
+    configuration_template = DynamicModelChoiceField(
+        required=False,
+        queryset=Template.objects.all(),
+        widget=APISelect(additional_query_params={"type": "configuration"}),
+        label="Configuration",
+        help_text="Template used to generate device configuration",
     )
     napalm_username = forms.CharField(required=False, label="Username")
     napalm_password = PasswordField(required=False, render_value=True, label="Password")
@@ -785,21 +694,12 @@ class RouterForm(BootstrapMixin, forms.ModelForm):
             "comments",
             "tags",
         )
-        labels = {"use_netbox": "Use NetBox", "configuration_template": "Configuration"}
-        help_texts = {
-            "hostname": "Router hostname (must be resolvable) or IP address",
-            "configuration_template": "Template used to generate device configuration",
-        }
-        widgets = {
-            "configuration_template": APISelect(
-                api_url="/api/peering/templates/",
-                query_filters={"type": "configuration"},
-            )
-        }
+        labels = {"use_netbox": "Use NetBox"}
+        help_texts = {"hostname": "Router hostname (must be resolvable) or IP address"}
 
 
 class RouterBulkEditForm(BootstrapMixin, AddRemoveTagsForm, BulkEditForm):
-    pk = FilterChoiceField(
+    pk = DynamicModelMultipleChoiceField(
         queryset=Router.objects.all(), widget=forms.MultipleHiddenInput
     )
     platform = forms.ChoiceField(
@@ -808,12 +708,10 @@ class RouterBulkEditForm(BootstrapMixin, AddRemoveTagsForm, BulkEditForm):
     encrypt_passwords = forms.NullBooleanField(
         required=False, label="Encrypt Passwords", widget=CustomNullBooleanSelect
     )
-    configuration_template = forms.ModelChoiceField(
+    configuration_template = DynamicModelChoiceField(
         required=False,
         queryset=Template.objects.all(),
-        widget=APISelect(
-            api_url="/api/peering/templates/", query_filters={"type": "configuration"}
-        ),
+        widget=APISelect(additional_query_params={"type": "configuration"}),
     )
     comments = CommentField(widget=SmallTextarea)
 
@@ -830,11 +728,11 @@ class RouterFilterForm(BootstrapMixin, forms.Form):
     encrypt_passwords = forms.NullBooleanField(
         required=False, label="Encrypt Passwords", widget=CustomNullBooleanSelect
     )
-    configuration_template = FilterChoiceField(
+    configuration_template = DynamicModelMultipleChoiceField(
+        required=False,
         queryset=Template.objects.all(),
         to_field_name="pk",
-        null_label=True,
-        widget=APISelectMultiple(api_url="/api/peering/templates/", null_option=True),
+        widget=APISelectMultiple(null_option=True),
     )
     tag = TagFilterField(model)
 
@@ -861,7 +759,7 @@ class RoutingPolicyForm(BootstrapMixin, forms.ModelForm):
 
 
 class RoutingPolicyBulkEditForm(BootstrapMixin, AddRemoveTagsForm, BulkEditForm):
-    pk = FilterChoiceField(
+    pk = DynamicModelMultipleChoiceField(
         queryset=RoutingPolicy.objects.all(), widget=forms.MultipleHiddenInput
     )
     type = forms.ChoiceField(

--- a/peering/models.py
+++ b/peering/models.py
@@ -1408,6 +1408,9 @@ class Router(ChangeLoggedModel, TaggableModel):
     def get_absolute_url(self):
         return reverse("peering:router_details", kwargs={"pk": self.pk})
 
+    def get_direct_peering_sessions_list_url(self):
+        return reverse("peering:router_direct_peering_sessions", kwargs={"pk": self.pk})
+
     def is_netbox_device(self):
         return self.netbox_device_id != 0
 

--- a/peering/urls.py
+++ b/peering/urls.py
@@ -88,11 +88,6 @@ urlpatterns = [
         views.BGPGroupPeeringSessions.as_view(),
         name="bgpgroup_peering_sessions",
     ),
-    path(
-        "bgp-groups/<slug:slug>/add-peering-session/",
-        views.BGPGroupPeeringSessionAdd.as_view(),
-        name="bgpgroup_peering_session_add",
-    ),
     # BGP Communities
     path("communities/", views.CommunityList.as_view(), name="community_list"),
     path("communities/add/", views.CommunityAdd.as_view(), name="community_add"),

--- a/peering/views.py
+++ b/peering/views.py
@@ -504,17 +504,6 @@ class DirectPeeringSessionAdd(PermissionRequiredMixin, AddOrEditView):
     form = DirectPeeringSessionForm
     template = "peering/session/direct/add_edit.html"
 
-    def alter_object(self, obj, request, args, kwargs):
-        if "autonomous_system" in request.GET:
-            obj.autonomous_system = get_object_or_404(
-                AutonomousSystem, pk=request.GET.get("autonomous_system")
-            )
-
-        return obj
-
-    def get_return_url(self, obj):
-        return obj.autonomous_system.get_direct_peering_sessions_list_url()
-
 
 class DirectPeeringSessionBulkDelete(PermissionRequiredMixin, BulkDeleteView):
     permission_required = "peering.delete_directpeeringsession"
@@ -550,9 +539,6 @@ class DirectPeeringSessionBulkEdit(PermissionRequiredMixin, BulkEditView):
 class DirectPeeringSessionDelete(PermissionRequiredMixin, DeleteView):
     permission_required = "peering.delete_directpeeringsession"
     model = DirectPeeringSession
-
-    def get_return_url(self, obj):
-        return obj.autonomous_system.get_direct_peering_sessions_list_url()
 
 
 class DirectPeeringSessionDetails(PermissionRequiredMixin, View):
@@ -776,17 +762,6 @@ class InternetExchangePeeringSessionAdd(PermissionRequiredMixin, AddOrEditView):
     form = InternetExchangePeeringSessionForm
     template = "peering/session/internet_exchange/add_edit.html"
 
-    def alter_object(self, obj, request, args, kwargs):
-        if "internet_exchange" in request.GET:
-            obj.internet_exchange = get_object_or_404(
-                InternetExchange, pk=request.GET.get("internet_exchange")
-            )
-
-        return obj
-
-    def get_return_url(self, obj):
-        return obj.internet_exchange.get_peering_sessions_list_url()
-
 
 class InternetExchangePeeringSessionBulkEdit(PermissionRequiredMixin, BulkEditView):
     permission_required = "peering.change_internetexchangepeeringsession"
@@ -823,9 +798,6 @@ class InternetExchangePeeringSessionEdit(PermissionRequiredMixin, AddOrEditView)
 class InternetExchangePeeringSessionDelete(PermissionRequiredMixin, DeleteView):
     permission_required = "peering.delete_internetexchangepeeringsession"
     model = InternetExchangePeeringSession
-
-    def get_return_url(self, obj):
-        return obj.internet_exchange.get_peering_sessions_list_url()
 
 
 class InternetExchangePeeringSessionAddFromPeeringDB(

--- a/peering/views.py
+++ b/peering/views.py
@@ -444,28 +444,6 @@ class BGPGroupPeeringSessions(PermissionRequiredMixin, ModelListView):
         return extra_context
 
 
-class BGPGroupPeeringSessionAdd(PermissionRequiredMixin, AddOrEditView):
-    permission_required = "peering.add_directpeeringsession"
-    model = DirectPeeringSession
-    form = DirectPeeringSessionForm
-    template = "peering/session/direct/add_edit.html"
-
-    def get_object(self, kwargs):
-        if "pk" in kwargs:
-            return get_object_or_404(self.model, pk=kwargs["pk"])
-
-        return self.model()
-
-    def alter_object(self, obj, request, args, kwargs):
-        if "slug" in kwargs:
-            obj.bgp_group = get_object_or_404(BGPGroup, slug=kwargs["slug"])
-
-        return obj
-
-    def get_return_url(self, obj):
-        return obj.bgp_group.get_peering_sessions_list_url()
-
-
 class CommunityList(PermissionRequiredMixin, ModelListView):
     permission_required = "peering.view_community"
     queryset = Community.objects.all()

--- a/peeringdb/forms.py
+++ b/peeringdb/forms.py
@@ -5,12 +5,12 @@ from utils.forms import (
     BootstrapMixin,
     BulkEditForm,
     CustomNullBooleanSelect,
-    FilterChoiceField,
+    DynamicModelMultipleChoiceField,
 )
 
 
 class PeerRecordBulkEditForm(BootstrapMixin, BulkEditForm):
-    pk = FilterChoiceField(
+    pk = DynamicModelMultipleChoiceField(
         queryset=PeerRecord.objects.all(), widget=forms.MultipleHiddenInput
     )
     visible = forms.NullBooleanField(required=False, widget=CustomNullBooleanSelect)

--- a/templates/peering/as/inc/direct_peering_sessions_table.html
+++ b/templates/peering/as/inc/direct_peering_sessions_table.html
@@ -1,6 +1,6 @@
 {% extends 'utils/object_list.html' %}
 {% block extra_buttons %}
-<a href="{% url 'peering:directpeeringsession_add' %}?autonomous_system={{ autonomous_system.pk }}" class="btn btn-sm btn-primary">
+<a href="{% url 'peering:directpeeringsession_add' %}?autonomous_system={{ autonomous_system.pk }}&return_url={{ autonomous_system.get_direct_peering_sessions_list_url }}" class="btn btn-sm btn-primary">
   <i class="fas fa-plus"></i> Add a Peering Session
 </a>
 {% endblock %}

--- a/templates/peering/bgp-group/inc/sessions_table.html
+++ b/templates/peering/bgp-group/inc/sessions_table.html
@@ -6,7 +6,7 @@
 </button>
 {% endif %}
 {% if perms.peering.add_directpeeringsession %}
-<a href="{% url 'peering:bgpgroup_peering_session_add' slug=bgp_group.slug %}" class="btn btn-sm btn-primary">
+<a href="{% url 'peering:directpeeringsession_add' %}?bgp_group={{ bgp_group.pk }}&return_url={{ bgp_group.get_peering_sessions_list_url }}" class="btn btn-sm btn-primary">
   <i class="fas fa-plus"></i> Add
 </a>
 {% endif %}

--- a/templates/peering/ix/inc/sessions_table.html
+++ b/templates/peering/ix/inc/sessions_table.html
@@ -11,7 +11,7 @@
   <i class="fas fa-upload"></i> Import from Router
 </button>
 {% endif %}
-<a href="{% url 'peering:internetexchangepeeringsession_add' %}?internet_exchange={{ internet_exchange.pk }}" class="btn btn-sm btn-primary">
+<a href="{% url 'peering:internetexchangepeeringsession_add' %}?internet_exchange={{ internet_exchange.pk }}&return_url={{ internet_exchange.get_peering_sessions_list_url }}" class="btn btn-sm btn-primary">
   <i class="fas fa-plus"></i> Add
 </a>
 {% endif %}

--- a/templates/peering/router/direct_peering_sessions.html
+++ b/templates/peering/router/direct_peering_sessions.html
@@ -3,7 +3,7 @@
 {% block subcontent %}
       <div class="row">
         <div class="col-md-9">
-          {% include 'utils/object_list.html' with bulk_edit_url='peering:directpeeringsession_bulk_edit' bulk_delete_url='peering:directpeeringsession_bulk_delete' %}
+          {% include 'peering/router/inc/sessions_table.html' with bulk_edit_url='peering:directpeeringsession_bulk_edit' bulk_delete_url='peering:directpeeringsession_bulk_delete' %}
         </div>
         <div class="col-md-3">
           {% include 'utils/search_form.html' %}

--- a/templates/peering/router/inc/sessions_table.html
+++ b/templates/peering/router/inc/sessions_table.html
@@ -1,0 +1,8 @@
+{% extends 'utils/object_list.html' %}
+{% block extra_buttons %}
+{% if perms.peering.add_directpeeringsession %}
+<a href="{% url 'peering:directpeeringsession_add' %}?router={{ router.pk }}&return_url={{ router.get_direct_peering_sessions_list_url }}" class="btn btn-sm btn-primary">
+  <i class="fas fa-plus"></i> Add
+</a>
+{% endif %}
+{% endblock %}

--- a/utils/templates/widgets/select_api.html
+++ b/utils/templates/widgets/select_api.html
@@ -1,9 +1,0 @@
-<select name="{{ widget.name }}"{% include "django/forms/widgets/attrs.html" %}>
-{% for group_name, group_choices, group_index in widget.optgroups %}
-{% if group_name %}<optgroup label="{{ group_name }}">{% endif %}
-{% for option in group_choices %}
-{% if option.attrs.selected or option.value == "null" %}{% include option.template_name with widget=option %}{% endif %}
-{% endfor %}
-{% if group_name %}</optgroup>{% endif %}
-{% endfor %}
-</select>

--- a/utils/views.py
+++ b/utils/views.py
@@ -26,7 +26,7 @@ from django_tables2 import RequestConfig
 from .filters import ObjectChangeFilterSet, TagFilterSet
 from .forms import (
     ConfirmationForm,
-    FilterChoiceField,
+    DynamicModelMultipleChoiceField,
     ObjectChangeFilterForm,
     TagBulkEditForm,
     TagFilterForm,
@@ -248,7 +248,7 @@ class BulkDeleteView(View):
 
     def get_form(self):
         class BulkDeleteForm(ConfirmationForm):
-            pk = FilterChoiceField(
+            pk = DynamicModelMultipleChoiceField(
                 queryset=self.model.objects.all(), widget=MultipleHiddenInput
             )
 

--- a/utils/views.py
+++ b/utils/views.py
@@ -37,10 +37,35 @@ from .paginators import EnhancedPaginator
 from .tables import ObjectChangeTable, TagTable
 
 
-class AddOrEditView(View):
+class ReturnURLMixin(object):
+    """
+    Provides a way to determine where a user should be redirected after processing a
+    form.
+    """
+
+    default_return_url = None
+
+    def get_return_url(self, request, obj=None):
+        # First, see if `return_url` was specified as a query parameter or form data.
+        # Use this URL only if it's considered safe.
+        query_param = request.GET.get("return_url") or request.POST.get("return_url")
+        if query_param and is_safe_url(
+            url=query_param, allowed_hosts=request.get_host()
+        ):
+            return query_param
+        # Next, check if the object being modified (if any) has an absolute URL.
+        elif obj is not None and obj.pk and hasattr(obj, "get_absolute_url"):
+            return obj.get_absolute_url()
+        # Fall back to the default URL (if specified) for the view.
+        elif self.default_return_url is not None:
+            return reverse(self.default_return_url)
+        # If all else fails, return home. Ideally this should never happen.
+        return reverse("home")
+
+
+class AddOrEditView(ReturnURLMixin, View):
     model = None
     form = None
-    return_url = None
     template = "utils/object_add_edit.html"
 
     def get_object(self, kwargs):
@@ -62,24 +87,14 @@ class AddOrEditView(View):
     def alter_object(self, obj, request, args, kwargs):
         return obj
 
-    def get_return_url(self, obj):
-        if obj.pk:
-            # If the object has an absolute URL, use it
-            return obj.get_absolute_url()
-
-        if self.return_url:
-            # Otherwise use the default URL if given
-            return reverse(self.return_url)
-
-        # Or return to home
-        return reverse("home")
-
     def get(self, request, *args, **kwargs):
         """
         Method used to render the view when form is not submitted.
         """
         obj = self.alter_object(self.get_object(kwargs), request, args, kwargs)
-        form = self.form(instance=obj, initial=request.GET)
+        # Parse initial data manually to avoid setting field values as lists
+        initial_data = {k: request.GET[k] for k in request.GET}
+        form = self.form(instance=obj, initial=initial_data)
 
         return render(
             request,
@@ -88,7 +103,7 @@ class AddOrEditView(View):
                 "object": obj,
                 "object_type": self.model._meta.verbose_name,
                 "form": form,
-                "return_url": self.get_return_url(obj),
+                "return_url": self.get_return_url(request, obj),
             },
         )
 
@@ -117,7 +132,7 @@ class AddOrEditView(View):
             if "_addanother" in request.POST:
                 return redirect(request.get_full_path())
 
-            return redirect(self.get_return_url(obj))
+            return redirect(self.get_return_url(request, obj))
 
         return render(
             request,
@@ -126,17 +141,16 @@ class AddOrEditView(View):
                 "object": obj,
                 "object_type": self.model._meta.verbose_name,
                 "form": form,
-                "return_url": self.get_return_url(obj),
+                "return_url": self.get_return_url(request, obj),
             },
         )
 
 
-class BulkAddFromDependencyView(View):
+class BulkAddFromDependencyView(ReturnURLMixin, View):
     model = None
     dependency_model = None
     custom_formset = None
     form_model = None
-    return_url = None
     template = "utils/table_import.html"
 
     def get_dependency_objects(self, pk_list):
@@ -151,17 +165,9 @@ class BulkAddFromDependencyView(View):
     def sort_objects(self, object_list):
         return []
 
-    def get_return_url(self):
-        if self.return_url:
-            # Use the default URL if given
-            return self.return_url
-
-        # Or return to home
-        return reverse("home")
-
     def get(self, request):
         # Don't allow direct GET requests
-        return redirect(self.get_return_url())
+        return redirect(self.get_return_url(request))
 
     def post(self, request):
         """
@@ -215,7 +221,7 @@ class BulkAddFromDependencyView(View):
                 )
                 messages.success(request, message)
 
-            return redirect(self.get_return_url())
+            return redirect(self.get_return_url(request))
 
         return render(
             request,
@@ -223,7 +229,7 @@ class BulkAddFromDependencyView(View):
             {
                 "formset": formset,
                 "obj_type": self.form_model._meta.model._meta.verbose_name,
-                "return_url": self.get_return_url(),
+                "return_url": self.get_return_url(request),
             },
         )
 
@@ -323,25 +329,13 @@ class BulkDeleteView(View):
         )
 
 
-class BulkEditView(View):
+class BulkEditView(ReturnURLMixin, View):
     queryset = None
     parent_model = None
     filter = None
     table = None
     form = None
     template = "utils/object_bulk_edit.html"
-    return_url = None
-
-    def get_return_url(self, request):
-        if self.return_url:
-            # Use the default URL if given
-            return self.return_url
-
-        if request.POST.get("return_url"):
-            return request.POST.get("return_url")
-
-        # Or return to home
-        return reverse("home")
 
     def get(self, request):
         return redirect(self.get_return_url(request))
@@ -444,7 +438,6 @@ class BulkEditView(View):
 
 
 class ConfirmationView(View):
-    return_url = None
     template = None
 
     def extra_context(self, kwargs):
@@ -471,9 +464,8 @@ class ConfirmationView(View):
         return render(request, self.template, context)
 
 
-class DeleteView(View):
+class DeleteView(ReturnURLMixin, View):
     model = None
-    return_url = None
     template = "utils/object_delete.html"
 
     def get_object(self, kwargs):
@@ -491,18 +483,6 @@ class DeleteView(View):
 
         return None
 
-    def get_return_url(self, obj):
-        if obj.pk:
-            # If the object has an absolute URL, use it
-            return obj.get_absolute_url()
-
-        if self.return_url:
-            # Otherwise use the default URL if given
-            return reverse(self.return_url)
-
-        # Or return to home
-        return reverse("home")
-
     def get(self, request, *args, **kwargs):
         """
         Method used to render the view when form is not submitted.
@@ -517,7 +497,7 @@ class DeleteView(View):
                 "object": obj,
                 "form": form,
                 "object_type": self.model._meta.verbose_name,
-                "return_url": self.get_return_url(obj),
+                "return_url": self.get_return_url(request, obj),
             },
         )
 
@@ -535,7 +515,7 @@ class DeleteView(View):
             message = "Deleted {} {}".format(self.model._meta.verbose_name, escape(obj))
             messages.success(request, message)
 
-            return redirect(self.get_return_url(obj))
+            return redirect(self.get_return_url(request, obj))
 
         return render(
             request,
@@ -544,7 +524,7 @@ class DeleteView(View):
                 "object": obj,
                 "form": form,
                 "object_type": self.model._meta.verbose_name,
-                "return_url": self.get_return_url(obj),
+                "return_url": self.get_return_url(request, obj),
             },
         )
 
@@ -636,22 +616,13 @@ class ModelListView(View):
         return render(request, self.template, context)
 
 
-class TableImportView(View):
+class TableImportView(ReturnURLMixin, View):
     custom_formset = None
     form_model = None
-    return_url = None
     template = "utils/table_import.html"
 
     def get_objects(self):
         return []
-
-    def get_return_url(self):
-        if self.return_url:
-            # Use the default URL if given
-            return reverse(self.return_url)
-
-        # Or return to home
-        return reverse("home")
 
     def get(self, request):
         """
@@ -670,7 +641,7 @@ class TableImportView(View):
             formset = ObjectFormSet(initial=objects)
         else:
             messages.info(request, "No data to import.")
-            return redirect(self.get_return_url())
+            return redirect(self.get_return_url(request))
 
         return render(
             request,
@@ -678,7 +649,7 @@ class TableImportView(View):
             {
                 "formset": formset,
                 "obj_type": self.form_model._meta.model._meta.verbose_name,
-                "return_url": self.get_return_url(),
+                "return_url": self.get_return_url(request),
             },
         )
 
@@ -709,7 +680,7 @@ class TableImportView(View):
                 )
                 messages.success(request, message)
 
-            return redirect(self.get_return_url())
+            return redirect(self.get_return_url(request))
 
         return render(
             request,
@@ -717,7 +688,7 @@ class TableImportView(View):
             {
                 "formset": formset,
                 "obj_type": self.form_model._meta.model._meta.verbose_name,
-                "return_url": self.get_return_url(),
+                "return_url": self.get_return_url(request),
             },
         )
 


### PR DESCRIPTION
Huge data preloading due to the way Django work for `<select>` (multiple) elements can be quite a performance killer. This PR is leveraging the API to avoid loading all the data by just loading the one that are already selected or by loading none of them and letting the API do its work.

This PR also includes a better way to redirect user after form submits by using a mixin class instead of overriding a method.