### PR TITLE
Fix user preference update in *PeeringSessions views

### DIFF
--- a/utils/views.py
+++ b/utils/views.py
@@ -611,7 +611,11 @@ class ModelListView(View):
 
         return render(request, self.template, context)
 
-    def post(self, request):
+    def post(self, request, *args, **kwargs):
+        # If no query set has been provided for some reasons
+        if not self.queryset:
+            self.queryset = self.build_queryset(request, kwargs)
+
         table = self.table(self.queryset)
         form = TableConfigurationForm(table=table, data=request.POST)
 


### PR DESCRIPTION
<!--
    Thank you for your interest in contributing to Peering Manager! Please
    indicate if your changes fix bugs or feature requests created in the issue
    tracker. This helps to avoid wasting time and effort to check for this
    before merging the code.

    Please indicate the relevant feature request or bug report below.
-->
### Fixes:
* The ModelViewList.post() method doesn't support additional kwargs which are supplied in some views causing the request to fail 
* The queryset attribute needs to be initialized otherwise it can be None, which will cause the construction of TableConfigurationForm to fail. 
